### PR TITLE
ietf-routing: fix invalid free() call + remove libnl memory leak

### DIFF
--- a/src/routing/route/next_hop.c
+++ b/src/routing/route/next_hop.c
@@ -13,7 +13,7 @@ void route_next_hop_set_simple(struct route_next_hop *nh, int ifindex, const cha
 {
 	nh->kind = route_next_hop_kind_simple;
 	nh->value.simple.ifindex = ifindex;
-	nh->value.simple.if_name = if_name;
+	nh->value.simple.if_name = xstrdup(if_name);
 	if (gw) {
 		nh->value.simple.addr = nl_addr_clone(gw);
 	} else {
@@ -43,7 +43,7 @@ void route_next_hop_add_list(struct route_next_hop *nh, int ifindex, const char 
 		idx = nh->value.list.size;
 	}
 	nh->value.list.list[idx].ifindex = ifindex;
-	nh->value.list.list[idx].if_name= if_name;
+	nh->value.list.list[idx].if_name = xstrdup(if_name);
 	if (gw) {
 		nh->value.list.list[idx].addr = nl_addr_clone(gw);
 	} else {
@@ -60,14 +60,14 @@ struct route_next_hop route_next_hop_clone(struct route_next_hop *nh)
 		case route_next_hop_kind_none:
 			break;
 		case route_next_hop_kind_simple:
-			route_next_hop_set_simple(&out, nh->value.simple.ifindex, xstrdup(nh->value.simple.if_name), nh->value.simple.addr);
+			route_next_hop_set_simple(&out, nh->value.simple.ifindex, nh->value.simple.if_name, nh->value.simple.addr);
 			break;
 		case route_next_hop_kind_special:
 			route_next_hop_set_special(&out, nh->value.special.value);
 			break;
 		case route_next_hop_kind_list:
 			for (int i = 0; i < nh->value.list.size; i++) {
-				route_next_hop_add_list(&out, nh->value.list.list[i].ifindex, xstrdup(nh->value.list.list[i].if_name), nh->value.list.list[i].addr);
+				route_next_hop_add_list(&out, nh->value.list.list[i].ifindex, nh->value.list.list[i].if_name, nh->value.list.list[i].addr);
 			}
 			break;
 	}

--- a/src/routing/routing.c
+++ b/src/routing/routing.c
@@ -163,14 +163,14 @@ int sr_plugin_init_cb(sr_session_ctx_t *session, void **private_data)
 	SRP_LOG_INF("subscribing to interfaces operational data");
 
 	// interface leaf-list oper data
-       error = sr_oper_get_items_subscribe(session, BASE_YANG_MODEL, ROUTING_INTERFACE_LEAF_LIST_YANG_PATH, routing_oper_get_interfaces_cb, NULL, SR_SUBSCR_CTX_REUSE, &subscription);
-       if (error) {
-               SRP_LOG_ERR("sr_oper_get_items_subscribe error (%d): %s", error, sr_strerror(error));
-               goto error_out;
-       }
+	error = sr_oper_get_items_subscribe(session, BASE_YANG_MODEL, ROUTING_INTERFACE_LEAF_LIST_YANG_PATH, routing_oper_get_interfaces_cb, NULL, SR_SUBSCR_CTX_REUSE, &subscription);
+	if (error) {
+		SRP_LOG_ERR("sr_oper_get_items_subscribe error (%d): %s", error, sr_strerror(error));
+		goto error_out;
+	}
 
-       // RIB oper data
-       error = sr_oper_get_items_subscribe(session, BASE_YANG_MODEL, ROUTING_RIB_LIST_YANG_PATH, routing_oper_get_rib_routes_cb, NULL, SR_SUBSCR_CTX_REUSE, &subscription);
+	// RIB oper data
+	error = sr_oper_get_items_subscribe(session, BASE_YANG_MODEL, ROUTING_RIB_LIST_YANG_PATH, routing_oper_get_rib_routes_cb, NULL, SR_SUBSCR_CTX_REUSE, &subscription);
 	if (error) {
 		SRP_LOG_ERR("sr_oper_get_items_subscribe error (%d): %s", error, sr_strerror(error));
 		goto error_out;
@@ -236,7 +236,6 @@ static int static_routes_init(struct route_list_hash **ipv4_routes, struct route
 		goto error_out;
 	}
 
-
 	route = (struct rtnl_route *) nl_cache_get_first(cache);
 	while (route != NULL) {
 		const int PROTO = rtnl_route_get_protocol(route);
@@ -289,14 +288,12 @@ out:
 	return error;
 }
 
-
 void sr_plugin_cleanup_cb(sr_session_ctx_t *session, void *private_data)
 {
 	route_list_hash_free(ipv4_static_routes);
 	route_list_hash_free(ipv6_static_routes);
 	FREE_SAFE(ipv4_static_routes);
 	FREE_SAFE(ipv6_static_routes);
-
 }
 
 static int routing_module_change_cb(sr_session_ctx_t *session, uint32_t subscription_id, const char *module_name, const char *xpath, sr_event_t event, uint32_t request_id, void *private_data)
@@ -348,7 +345,6 @@ static int routing_module_change_cb(sr_session_ctx_t *session, uint32_t subscrip
 			}
 
 			SRP_LOG_DBG("node_xpath: %s; prev_val: %s; node_val: %s; operation: %d", node_xpath, prev_value, node_value, operation);
-
 
 			if (node->schema->nodetype == LYS_LEAF || node->schema->nodetype == LYS_LEAFLIST) {
 				if (strstr(node_xpath, "ietf-ipv4-unicast-routing:ipv4")) {
@@ -486,8 +482,7 @@ static int update_static_routes(struct route_list_hash *routes, uint8_t family)
 				goto error_out;
 			}
 
-			if (routes->list_route[i].list[0].next_hop.value.simple.if_name == NULL
-					&& routes->list_route[i].list[0].next_hop.value.simple.addr == NULL) {
+			if (routes->list_route[i].list[0].next_hop.value.simple.if_name == NULL && routes->list_route[i].list[0].next_hop.value.simple.addr == NULL) {
 				error = -1;
 				SRP_LOG_ERR("outgoing-interface and next-hop-address can't both be NULL");
 				goto error_out;
@@ -513,7 +508,6 @@ static int update_static_routes(struct route_list_hash *routes, uint8_t family)
 				rtnl_route_nh_set_ifindex(next_hop, routes->list_route[i].list[0].next_hop.value.list.list[j].ifindex);
 				rtnl_route_nh_set_gateway(next_hop, routes->list_route[i].list[0].next_hop.value.list.list[j].addr);
 				rtnl_route_add_nexthop(route, next_hop);
-
 			}
 		}
 
@@ -564,8 +558,7 @@ static int set_control_plane_protocol_value(char *node_xpath, char *node_value)
 	name_key = sr_xpath_key_value(node_xpath, "control-plane-protocol", "name", &xpath_ctx);
 	type_key = sr_xpath_key_value(node_xpath, "control-plane-protocol", "type", &xpath_ctx);
 
-	if (!strcmp(node_name, "description") && !strstr(orig_xpath, "ietf-ipv4-unicast-routing:ipv4")
-			&& !strstr(orig_xpath, "ietf-ipv6-unicast-routing:ipv6")) {
+	if (!strcmp(node_name, "description") && !strstr(orig_xpath, "ietf-ipv4-unicast-routing:ipv4") && !strstr(orig_xpath, "ietf-ipv6-unicast-routing:ipv6")) {
 		error = routing_control_plane_protocol_set_description(type_key, name_key, node_value);
 		if (error != 0) {
 			SRP_LOG_ERR("routing_control_plane_protocol_set_description failed");
@@ -716,8 +709,7 @@ static int delete_control_plane_protocol_value(char *node_xpath)
 	name_key = sr_xpath_key_value(node_xpath, "control-plane-protocol", "name", &xpath_ctx);
 	type_key = sr_xpath_key_value(node_xpath, "control-plane-protocol", "type", &xpath_ctx);
 
-	if (!strcmp(node_name, "description") && !strstr(orig_xpath, "ietf-ipv4-unicast-routing:ipv4")
-			&& !strstr(orig_xpath, "ietf-ipv6-unicast-routing:ipv6")) {
+	if (!strcmp(node_name, "description") && !strstr(orig_xpath, "ietf-ipv4-unicast-routing:ipv4") && !strstr(orig_xpath, "ietf-ipv6-unicast-routing:ipv6")) {
 		error = routing_control_plane_protocol_set_description(type_key, name_key, "");
 		if (error != 0) {
 			SRP_LOG_ERR("routing_control_plane_protocol_set_description failed");
@@ -1732,6 +1724,9 @@ static int routing_collect_routes(struct nl_cache *routes_cache, struct nl_cache
 			iface = rtnl_link_get(link_cache, ifindex);
 			if_name = rtnl_link_get_name(iface);
 			route_next_hop_set_simple(&tmp_route.next_hop, ifindex, if_name, rtnl_route_nh_get_gateway(nh));
+
+			// free recieved link
+			rtnl_link_put(iface);
 		} else {
 			rtnl_route_foreach_nexthop(route, foreach_nexthop, &tmp_route.next_hop);
 		}
@@ -1841,7 +1836,7 @@ static int routing_load_control_plane_protocols(sr_session_ctx_t *session, struc
 	// control plane protocols container created - add all protocols to the inner list
 
 	// add the data to the datastore
-	for (size_t i  = 0; i < ROUTING_PROTOS_COUNT; i++) {
+	for (size_t i = 0; i < ROUTING_PROTOS_COUNT; i++) {
 		const struct control_plane_protocol *proto = &cpp_map[i];
 		if (proto->initialized) {
 			// write proto path - type + name are added automatically when creating the list node


### PR DESCRIPTION
Retrieving RIB operational data should now work without any double `free()` calls or memory leaks related to **libnl**.