### PR TITLE
interfaces-plugin: refactor (libyang1)

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     ip_data.c
     ipv6_data.c
     if_nic_stats.c
+    datastore.c
     ${CMAKE_SOURCE_DIR}/src/utils/memory.c
 )
 

--- a/src/interfaces/datastore.c
+++ b/src/interfaces/datastore.c
@@ -14,7 +14,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <linux/limits.h>
+
 #include <sysrepo.h>
+#include <libyang/libyang.h>
+#include <libyang/tree_data.h>
 
 #include "datastore.h"
 
@@ -221,6 +224,114 @@ int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_na
 				   IF_IPV6_NEIGH_LEAF_COUNT, leaf_values, true);
 	if (error) {
 		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_oper_info_leaf_names[IF_OPER_LEAF_COUNT] = {
+	[IF_ADMIN_STATUS] = "admin-status",
+	[IF_OPER_STATUS] = "oper-status",
+	[IF_LAST_CHANGE] = "last-change",
+	[IF_IF_INDEX] = "if-index",
+	[IF_PHYS_ADDRESS] = "phys-address",
+	[IF_SPEED] = "speed"
+};
+
+int ds_oper_set_interface_info(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name,
+			       char *leaf_values[IF_OPER_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	for (uint32_t i = 0; i < IF_OPER_LEAF_COUNT; i++) {
+		if (leaf_values[i] == NULL) {
+			continue;
+		}
+		char xpath[PATH_MAX] = {0};
+		error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/%s", INTERFACE_LIST_YANG_PATH,
+				 interface_name, interface_oper_info_leaf_names[i]);
+		if (error < 0) {
+			SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+			goto out;
+		}
+		error = 0;
+		SRP_LOG_DBG("%s = %s", xpath, leaf_values[i]);
+		lyd_new_path(parent, ly_ctx, xpath, leaf_values[i], LYD_ANYDATA_STRING, 0);
+	}
+out:
+	return error;
+}
+
+int ds_oper_add_interface_higher_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx,
+					  char *interface_name, char *higher_layer_if)
+{
+	int error = SR_ERR_OK;
+	char xpath[PATH_MAX] = {0};
+	error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/higher-layer-if",
+			 INTERFACE_LIST_YANG_PATH, interface_name);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = 0;
+	SRP_LOG_DBG("%s += %s", xpath, higher_layer_if);
+	lyd_new_path(parent, ly_ctx, xpath, higher_layer_if, LYD_ANYDATA_STRING, 0);
+out:
+	return error;
+}
+
+int ds_oper_add_interface_lower_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx,
+					 char *interface_name, char *lower_layer_if)
+{
+	int error = SR_ERR_OK;
+	char xpath[PATH_MAX] = {0};
+	error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/lower-layer-if",
+			 INTERFACE_LIST_YANG_PATH, interface_name);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = 0;
+	SRP_LOG_DBG("%s += %s", xpath, lower_layer_if);
+	lyd_new_path(parent, ly_ctx, xpath, lower_layer_if, LYD_ANYDATA_STRING, 0);
+out:
+	return error;
+}
+
+static char *interface_statistics_leaf_names[IF_STATS_LEAF_COUNT] = {
+	[IF_STATS_DISCONTINUITY_TIME] = "discontinuity-time",
+	[IF_STATS_IN_OCTETS] = "in-octets",
+	[IF_STATS_IN_UNICAST_PKTS] = "in-unicast-pkts",
+	[IF_STATS_IN_BROADCAST_PKTS] = "in-broadcast-pkts",
+	[IF_STATS_IN_MULTICAST_PKTS] = "in-multicast-pkts",
+	[IF_STATS_IN_DISCARDS] = "in-discards",
+	[IF_STATS_IN_ERRORS] = "in-errors",
+	[IF_STATS_IN_UNKNOWN_PROTOS] = "in-unknown-protos",
+	[IF_STATS_OUT_OCTETS] = "out-octets",
+	[IF_STATS_OUT_UNICAST_PKTS] = "out-unicast-pkts",
+	[IF_STATS_OUT_BROADCAST_PKTS] = "out-broadcast-pkts",
+	[IF_STATS_OUT_MULTICAST_PKTS] = "out-multicast-pkts",
+	[IF_STATS_OUT_DISCARDS] = "out-discards",
+	[IF_STATS_OUT_ERRORS] = "out-errors"
+};
+
+int ds_oper_set_interface_statistics(struct lyd_node *parent, const struct ly_ctx *ly_ctx,
+				     char *interface_name, char *leaf_values[IF_STATS_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	for (uint32_t i = 0; i < IF_STATS_LEAF_COUNT; i++) {
+		if (leaf_values[i] == NULL) {
+			continue;
+		}
+		char xpath[PATH_MAX] = {0};
+		error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/statistics/%s", INTERFACE_LIST_YANG_PATH,
+				 interface_name, interface_statistics_leaf_names[i]);
+		if (error < 0) {
+			SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+			goto out;
+		}
+		error = 0;
+		SRP_LOG_DBG("%s = %s", xpath, leaf_values[i]);
+		lyd_new_path(parent, ly_ctx, xpath, leaf_values[i], LYD_ANYDATA_STRING, 0);
 	}
 out:
 	return error;

--- a/src/interfaces/datastore.c
+++ b/src/interfaces/datastore.c
@@ -1,0 +1,227 @@
+/*
+ * telekom / sysrepo-plugin-interfaces
+ *
+ * This program is made available under the terms of the
+ * BSD 3-Clause license which is available at
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * SPDX-FileCopyrightText: 2021 Deutsche Telekom AG
+ * SPDX-FileContributor: Sartura Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <linux/limits.h>
+#include <sysrepo.h>
+
+#include "datastore.h"
+
+/*
+ * Set the value of multiple YANG module leafs. The path for each leaf node is determined
+ * by concatenating base_xpath with its name from leaf_names. All leaf nodes with a non-NULL
+ * entry in leaf_values will be set.
+ */
+static int ds_set_leaf_values(sr_session_ctx_t *session, char *base_xpath, char **leaf_names,
+			      uint32_t leaf_count, char **leaf_values, bool log_changes)
+{
+	int error = SR_ERR_OK;
+	char xpath[PATH_MAX] = {0};
+
+	for (uint32_t i = 0; i < leaf_count; i++) {
+		if (leaf_values[i] == NULL) {
+			continue;
+		}
+		error = snprintf(xpath, sizeof(xpath), "%s/%s", base_xpath, leaf_names[i]);
+		if (error < 0) {
+			SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+			goto out;
+		}
+		error = sr_set_item_str(session, xpath, leaf_values[i], NULL, SR_EDIT_DEFAULT);
+		if (error) {
+			SRP_LOG_ERR("sr_set_item_str error (%d): %s", error, sr_strerror(error));
+			goto out;
+		}
+		if (log_changes) {
+			SRP_LOG_DBG("%s = %s", xpath, leaf_values[i]);
+		}
+	}
+out:
+	return error;
+}
+
+static char *interface_leaf_names[IF_LEAF_COUNT] = {
+	[IF_NAME] = "name",
+	[IF_TYPE] = "type",
+	[IF_DESCRIPTION] = "description",
+	[IF_ENABLED] = "enabled",
+	[IF_PARENT_INTERFACE] = "ietf-if-extensions:parent-interface"
+};
+
+int ds_set_general_interface_config(sr_session_ctx_t *session, char *interface_name,
+				    char *leaf_values[IF_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]",
+			 INTERFACE_LIST_YANG_PATH, interface_name);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_leaf_names,
+				   IF_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+/* Leaf nodes defined for both ipv4 and ipv6 */
+static char *interface_ip_leaf_names[IF_IP_LEAF_COUNT] = {
+	[IF_IP_ENABLED] = "enabled",
+	[IF_IP_FORWARDING] = "forwarding",
+	[IF_IP_MTU] = "mtu"
+};
+
+int ds_set_interface_ip_config(sr_session_ctx_t *session, char *interface_name, char *ip_version,
+			       char *leaf_values[IF_IP_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:%s",
+			 INTERFACE_LIST_YANG_PATH, interface_name, ip_version);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ip_leaf_names,
+				   IF_IP_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+int ds_set_interface_ipv4_config(sr_session_ctx_t *session, char *interface_name,
+				 char *leaf_values[IF_IP_LEAF_COUNT])
+{
+	return ds_set_interface_ip_config(session, interface_name, "ipv4", leaf_values);
+}
+
+int ds_set_interface_ipv6_config(sr_session_ctx_t *session, char *interface_name,
+				 char *leaf_values[IF_IP_LEAF_COUNT])
+{
+	return ds_set_interface_ip_config(session, interface_name, "ipv6", leaf_values);
+}
+
+static char *interface_ipv4_addr_leaf_names[IF_IPV4_ADDR_LEAF_COUNT] = {
+	[IF_IPV4_ADDR_IP] = "ip",
+	[IF_IPV4_ADDR_SUBNET] = "subnet",
+	[IF_IPV4_ADDR_PREFIX_LENGTH] = "prefix-length",
+	[IF_IPV4_ADDR_ORIGIN] = "origin"
+};
+
+int ds_add_interface_ipv4_address(sr_session_ctx_t *session, char *interface_name,
+				  char *leaf_values[IF_IPV4_ADDR_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv4/address[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, leaf_values[IF_IPV4_ADDR_IP]);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv4_addr_leaf_names,
+				   IF_IPV4_ADDR_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_ipv4_neigh_leaf_names[IF_IPV4_NEIGH_LEAF_COUNT] = {
+	[IF_IPV4_NEIGH_IP] = "ip",
+	[IF_IPV4_NEIGH_LINK_LAYER_ADDR] = "link-layer-address",
+	[IF_IPV4_NEIGH_ORIGIN] = "origin"
+};
+
+int ds_add_interface_ipv4_neighbor(sr_session_ctx_t *session, char *interface_name,
+				   char *leaf_values[IF_IPV4_NEIGH_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv4/neighbor[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, leaf_values[IF_IPV4_NEIGH_IP]);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv4_neigh_leaf_names,
+				   IF_IPV4_NEIGH_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_ipv6_addr_leaf_names[IF_IPV6_ADDR_LEAF_COUNT] = {
+	[IF_IPV6_ADDR_IP] = "ip",
+	[IF_IPV6_ADDR_PREFIX_LENGTH] = "prefix-length",
+	[IF_IPV6_ADDR_ORIGIN] = "origin",
+	[IF_IPV6_ADDR_STATUS] = "status"
+};
+
+int ds_add_interface_ipv6_address(sr_session_ctx_t *session, char *interface_name,
+				  char *leaf_values[IF_IPV6_ADDR_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv6/address[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, leaf_values[IF_IPV6_ADDR_IP]);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv6_addr_leaf_names,
+				   IF_IPV6_ADDR_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_ipv6_neigh_leaf_names[IF_IPV6_NEIGH_LEAF_COUNT] = {
+	[IF_IPV6_NEIGH_IP] = "ip",
+	[IF_IPV6_NEIGH_LINK_LAYER_ADDR] = "link-layer-address",
+	[IF_IPV6_NEIGH_ORIGIN] = "origin",
+	[IF_IPV6_NEIGH_IS_ROUTER] = "is-router",
+	[IF_IPV6_NEIGH_STATE] = "state"
+};
+
+int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_name,
+				   char *leaf_values[IF_IPV6_NEIGH_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv6/neighbor[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, leaf_values[IF_IPV6_NEIGH_IP]);
+	if (error < 0) {
+		SRP_LOG_ERR("snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv6_neigh_leaf_names,
+				   IF_IPV6_NEIGH_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRP_LOG_ERR("ds_set_leaf_values error");
+	}
+out:
+	return error;
+}

--- a/src/interfaces/datastore.h
+++ b/src/interfaces/datastore.h
@@ -82,4 +82,39 @@ enum interface_ipv6_neighbour_leaf {
 
 int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IPV6_NEIGH_LEAF_COUNT]);
 
+enum interface_oper_info_leaf {
+	IF_ADMIN_STATUS,
+	IF_OPER_STATUS,
+	IF_LAST_CHANGE,
+	IF_IF_INDEX,
+	IF_PHYS_ADDRESS,
+	IF_SPEED,
+	IF_OPER_LEAF_COUNT
+};
+
+int ds_oper_set_interface_info(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *leaf_values[IF_OPER_LEAF_COUNT]);
+
+int ds_oper_add_interface_higher_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *higher_layer_if);
+int ds_oper_add_interface_lower_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *lower_layer_if);
+
+enum interface_statistics_leaf {
+	IF_STATS_DISCONTINUITY_TIME,
+	IF_STATS_IN_OCTETS,
+	IF_STATS_IN_UNICAST_PKTS,
+	IF_STATS_IN_BROADCAST_PKTS,
+	IF_STATS_IN_MULTICAST_PKTS,
+	IF_STATS_IN_DISCARDS,
+	IF_STATS_IN_ERRORS,
+	IF_STATS_IN_UNKNOWN_PROTOS,
+	IF_STATS_OUT_OCTETS,
+	IF_STATS_OUT_UNICAST_PKTS,
+	IF_STATS_OUT_BROADCAST_PKTS,
+	IF_STATS_OUT_MULTICAST_PKTS,
+	IF_STATS_OUT_DISCARDS,
+	IF_STATS_OUT_ERRORS,
+	IF_STATS_LEAF_COUNT
+};
+
+int ds_oper_set_interface_statistics(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *leaf_values[IF_STATS_LEAF_COUNT]);
+
 #endif // DATASTORE_H_ONCE

--- a/src/interfaces/datastore.h
+++ b/src/interfaces/datastore.h
@@ -1,0 +1,85 @@
+/*
+ * telekom / sysrepo-plugin-interfaces
+ *
+ * This program is made available under the terms of the
+ * BSD 3-Clause license which is available at
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * SPDX-FileCopyrightText: 2021 Deutsche Telekom AG
+ * SPDX-FileContributor: Sartura Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DATASTORE_H_ONCE
+#define DATASTORE_H_ONCE
+
+#define BASE_YANG_MODEL "ietf-interfaces"
+#define BASE_IP_YANG_MODEL "ietf-ip"
+// config data
+#define INTERFACES_YANG_MODEL "/" BASE_YANG_MODEL ":interfaces"
+#define INTERFACE_LIST_YANG_PATH INTERFACES_YANG_MODEL "/interface"
+
+enum interface_general_leaf {
+	IF_NAME = 0,
+	IF_TYPE,
+	IF_DESCRIPTION,
+	IF_ENABLED,
+	IF_PARENT_INTERFACE,
+	IF_LEAF_COUNT
+};
+
+int ds_set_general_interface_config(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_LEAF_COUNT]);
+
+/* leaf nodes defined for both ipv4 and ipv6 */
+enum interface_ip_leaf {
+	IF_IP_ENABLED = 0,
+	IF_IP_FORWARDING,
+	IF_IP_MTU,
+	IF_IP_LEAF_COUNT
+};
+
+int ds_set_interface_ipv4_config(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IP_LEAF_COUNT]);
+int ds_set_interface_ipv6_config(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IP_LEAF_COUNT]);
+
+enum interface_ipv4_addr_leaf {
+	IF_IPV4_ADDR_IP = 0,
+	IF_IPV4_ADDR_SUBNET,
+	IF_IPV4_ADDR_PREFIX_LENGTH,
+	IF_IPV4_ADDR_ORIGIN,
+	IF_IPV4_ADDR_LEAF_COUNT
+};
+
+int ds_add_interface_ipv4_address(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IPV4_ADDR_LEAF_COUNT]);
+
+enum interface_ipv4_neighbour_leaf {
+	IF_IPV4_NEIGH_IP = 0,
+	IF_IPV4_NEIGH_LINK_LAYER_ADDR,
+	IF_IPV4_NEIGH_ORIGIN,
+	IF_IPV4_NEIGH_LEAF_COUNT
+};
+
+int ds_add_interface_ipv4_neighbor(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IPV4_NEIGH_LEAF_COUNT]);
+
+enum interface_ipv6_addr_leaf {
+	IF_IPV6_ADDR_IP = 0,
+	IF_IPV6_ADDR_PREFIX_LENGTH,
+	IF_IPV6_ADDR_ORIGIN,
+	IF_IPV6_ADDR_STATUS,
+	IF_IPV6_ADDR_LEAF_COUNT
+};
+
+int ds_add_interface_ipv6_address(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IPV6_ADDR_LEAF_COUNT]);
+
+enum interface_ipv6_neighbour_leaf {
+	IF_IPV6_NEIGH_IP = 0,
+	IF_IPV6_NEIGH_LINK_LAYER_ADDR,
+	IF_IPV6_NEIGH_ORIGIN,
+	IF_IPV6_NEIGH_IS_ROUTER,
+	IF_IPV6_NEIGH_STATE,
+	IF_IPV6_NEIGH_LEAF_COUNT
+};
+
+int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IPV6_NEIGH_LEAF_COUNT]);
+
+#endif // DATASTORE_H_ONCE

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2473,10 +2473,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 	struct rtnl_tc *tc = NULL;
 	struct rtnl_qdisc *qdisc = NULL;
 
-	int32_t tmp_if_index = 0;
-	uint64_t tmp_len = 0;
-	struct rtnl_link *tmp_link = NULL;
-
 	char tmp_buffer[PATH_MAX] = {0};
 	char xpath_buffer[PATH_MAX] = {0};
 	char interface_path_buffer[PATH_MAX] = {0};
@@ -2496,10 +2492,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 		struct tm *last_change;
 		int32_t if_index;
 		char *phys_address;
-		struct {
-			char *masters[LD_MAX_LINKS];
-			uint32_t count;
-		} higher_layer_if;
 		uint64_t speed;
 		struct {
 			char *discontinuity_time;
@@ -2518,32 +2510,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 			uint32_t out_errors;
 		} statistics;
 	} interface_data = {0};
-
-	typedef struct {
-		char *slave_name;
-		char *master_names[LD_MAX_LINKS];
-		uint32_t count;
-	} master_t;
-
-	typedef struct {
-		master_t masters[LD_MAX_LINKS];
-		uint32_t count;
-	} master_list_t;
-
-	master_list_t master_list = {0};
-
-	typedef struct {
-		char *master_name;
-		char *slave_names[LD_MAX_LINKS];
-		uint32_t count;
-	} slave_t;
-
-	typedef struct {
-		slave_t slaves[LD_MAX_LINKS];
-		uint32_t count;
-	} slave_list_t;
-
-	slave_list_t slave_list = {0};
 
 	const char *OPER_STRING_MAP[] = {
 		[IF_OPER_UNKNOWN] = "unknown",
@@ -2579,85 +2545,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 	if (error != 0) {
 		SRP_LOG_ERR("rtnl_link_alloc_cache error (%d): %s", error, nl_geterror(error));
 		goto error_out;
-	}
-
-	// collect all master interfaces
-	link = (struct rtnl_link *) nl_cache_get_first(cache);
-
-	while (link != NULL) {
-		char *slave_name = rtnl_link_get_name(link);
-
-		// higher-layer-if
-		tmp_if_index = rtnl_link_get_master(link);
-		while (tmp_if_index) {
-			tmp_link = rtnl_link_get(cache, tmp_if_index);
-
-			char *master_name = rtnl_link_get_name(tmp_link);
-
-			tmp_len = strlen(master_name);
-
-			interface_data.higher_layer_if.masters[interface_data.higher_layer_if.count] = xstrndup(master_name, tmp_len);
-
-			interface_data.higher_layer_if.count++;
-
-			tmp_if_index = rtnl_link_get_master(tmp_link);
-		}
-
-		if (interface_data.higher_layer_if.count > 0) {
-			for (uint64_t i = 0; i < interface_data.higher_layer_if.count; i++) {
-				char *master_name = interface_data.higher_layer_if.masters[i];
-
-				tmp_len = strlen(slave_name);
-				master_list.masters[master_list.count].slave_name = xstrndup(slave_name, tmp_len);
-
-				tmp_len = strlen(master_name);
-				master_list.masters[master_list.count].master_names[i] = xstrndup(master_name, tmp_len);
-			}
-
-			master_list.masters[master_list.count].count = interface_data.higher_layer_if.count;
-			master_list.count++;
-		}
-
-		// continue to next link node
-		link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);
-	}
-
-	// collect all slave interfaces
-	link = (struct rtnl_link *) nl_cache_get_first(cache);
-
-	while (link != NULL) {
-		// lower-layer-if
-		char *if_name = rtnl_link_get_name(link);
-
-		bool break_out = false;
-		for (uint64_t i = 0; i < master_list.count; i++) {
-			for (uint64_t j = 0; j < master_list.masters[i].count; j++) {
-				if (strcmp(master_list.masters[i].slave_name, master_list.masters[i].master_names[j]) == 0) {
-					continue;
-				}
-
-				if (strcmp(master_list.masters[i].master_names[j], if_name) == 0) {
-					SRP_LOG_DBG("Slave of interface %s: %s", if_name, master_list.masters[i].slave_name);
-
-					tmp_len = strlen(if_name);
-					slave_list.slaves[slave_list.count].master_name = xstrndup(if_name, tmp_len);
-
-					tmp_len = strlen(master_list.masters[i].slave_name);
-					slave_list.slaves[slave_list.count].slave_names[i] = xstrndup(master_list.masters[i].slave_name, tmp_len);
-
-					slave_list.slaves[slave_list.count].count++;
-
-					break_out = true;
-					break;
-				}
-			}
-			if (break_out) {
-				slave_list.count++;
-				break;
-			}
-		}
-		// continue to next link node
-		link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);
 	}
 
 	char system_boot_time[DATETIME_BUF_SIZE] = {0};
@@ -2803,38 +2690,27 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 			goto error_out;
 		}
 
-		// higher-layer-if
-		for (uint64_t i = 0; i < master_list.count; i++) {
-			if (strcmp(interface_data.name, master_list.masters[i].slave_name) == 0) {
-				for (uint64_t j = 0; j < master_list.masters[i].count; j++) {
+		// find all interfaces which are layered on top of this interface
+		// and update the operational datastore accordingly
+		int32_t master_if_index = rtnl_link_get_master(link);
+		struct rtnl_link *master_link = NULL;
+		while (master_if_index) {
+			master_link = rtnl_link_get(cache, master_if_index);
+			char *master_name = rtnl_link_get_name(master_link);
 
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/higher-layer-if", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRP_LOG_DBG("%s += %s", xpath_buffer, master_list.masters[i].master_names[j]);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, master_list.masters[i].master_names[j], LYD_ANYDATA_STRING, 0);
-
-					FREE_SAFE(interface_data.higher_layer_if.masters[i]);
-				}
+			error = ds_oper_add_interface_higher_layer_if(*parent, ly_ctx, interface_data.name, master_name);
+			if (error) {
+				SRP_LOG_ERR("ds_oper_add_interface_higher_layer_if error");
+				goto error_out;
 			}
-		}
-
-		// lower-layer-if
-		for (uint64_t i = 0; i < slave_list.count; i++) {
-			if (strcmp(interface_data.name, slave_list.slaves[i].master_name) == 0) {
-				for (uint64_t j = 0; j < slave_list.slaves[i].count; j++) {
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/lower-layer-if", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRP_LOG_DBG("%s += %s", xpath_buffer, slave_list.slaves[i].slave_names[j]);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, slave_list.slaves[i].slave_names[j], LYD_ANYDATA_STRING, 0);
-				}
+			error = ds_oper_add_interface_lower_layer_if(*parent, ly_ctx, master_name, interface_data.name);
+			if (error) {
+				SRP_LOG_ERR("ds_oper_add_interface_lower_layer_if error");
+				goto error_out;
 			}
+
+			// go one layer higher
+			master_if_index = rtnl_link_get_master(master_link);
 		}
 
 		// ietf-ip
@@ -3037,20 +2913,6 @@ error_out:
 	error = SR_ERR_CALLBACK_FAILED;
 
 out:
-	for (uint64_t i = 0; i < master_list.count; i++) {
-		for (uint64_t j = 0; j < master_list.masters[i].count; j++) {
-			FREE_SAFE(master_list.masters[i].master_names[j]);
-		}
-		FREE_SAFE(master_list.masters[i].slave_name);
-	}
-
-	for (uint64_t i = 0; i < slave_list.count; i++) {
-		for (uint64_t j = 0; j < slave_list.slaves[i].count; j++) {
-			FREE_SAFE(slave_list.slaves[i].slave_names[j]);
-		}
-		FREE_SAFE(slave_list.slaves[i].master_name);
-	}
-
 	nl_socket_free(socket);
 	return error ? SR_ERR_CALLBACK_FAILED : SR_ERR_OK;
 }

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2717,14 +2717,15 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 		snprintf(speed, sizeof(speed), "%lu", rtnl_tc_get_stat(tc, RTNL_TC_RATE_BPS));
 		interface_oper_leaf_values[IF_SPEED] = speed;
 
+		// set interface state info in operational ds
 		error = ds_oper_set_interface_info(*parent, ly_ctx, interface_data.name, interface_oper_leaf_values);
 		if (error) {
 			SRP_LOG_ERR("ds_oper_set_interface_info error");
 			goto error_out;
 		}
 
-		// stats:
-		interface_data.statistics.discontinuity_time = system_boot_time;
+		// collect operational statistics
+		char *statistics[IF_STATS_LEAF_COUNT] = {NULL};
 
 		// gather interface statistics that are not accessable via netlink
 		nic_stats_t nic_stats = {0};
@@ -2733,29 +2734,74 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 			SRP_LOG_ERR("get_nic_stats error: %s", strerror(errno));
 		}
 
-		// Rx
-		interface_data.statistics.in_octets = rtnl_link_get_stat(link, RTNL_LINK_RX_BYTES);
-		interface_data.statistics.in_broadcast_pkts = nic_stats.rx_broadcast;
-		interface_data.statistics.in_multicast_pkts = rtnl_link_get_stat(link, RTNL_LINK_MULTICAST);
-		interface_data.statistics.in_unicast_pkts = nic_stats.rx_packets - nic_stats.rx_broadcast - interface_data.statistics.in_multicast_pkts;
-
-		interface_data.statistics.in_discards = (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_RX_DROPPED);
-		interface_data.statistics.in_errors = (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_RX_ERRORS);
-		interface_data.statistics.in_unknown_protos = (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_IP6_INUNKNOWNPROTOS);
-
-		// Tx
-		interface_data.statistics.out_octets = rtnl_link_get_stat(link, RTNL_LINK_TX_BYTES);
-		interface_data.statistics.out_broadcast_pkts = nic_stats.tx_broadcast;
-		interface_data.statistics.out_multicast_pkts = nic_stats.tx_multicast;
-		interface_data.statistics.out_unicast_pkts = nic_stats.tx_packets - nic_stats.tx_broadcast - nic_stats.tx_multicast;
-
-		interface_data.statistics.out_discards = (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_TX_DROPPED);
-		interface_data.statistics.out_errors = (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_TX_ERRORS);
-
 		snprintf(interface_path_buffer, sizeof(interface_path_buffer) / sizeof(char), "%s[name=\"%s\"]", INTERFACE_LIST_YANG_PATH, rtnl_link_get_name(link));
 
+		// discontinuity-time
+		statistics[IF_STATS_DISCONTINUITY_TIME] =  system_boot_time;
 
+		// Rx
+		// in-octets
+		char in_octets[32] = {0};
+		snprintf(in_octets, sizeof(in_octets), "%lu", rtnl_link_get_stat(link, RTNL_LINK_RX_BYTES));
+		statistics[IF_STATS_IN_OCTETS] = in_octets;
+		// in-broadcast-pkts
+		char in_broadcast_pkts[32] = {0};
+		snprintf(in_broadcast_pkts, sizeof(in_broadcast_pkts), "%lu", nic_stats.rx_broadcast);
+		statistics[IF_STATS_IN_BROADCAST_PKTS] = in_broadcast_pkts;
+		// in-multicast-pkts
+		uint64_t in_multicast_pkts = rtnl_link_get_stat(link, RTNL_LINK_MULTICAST);
+		char in_multicast_pkts_str[32] = {0};
+		snprintf(in_multicast_pkts_str, sizeof(in_multicast_pkts_str), "%lu", in_multicast_pkts);
+		statistics[IF_STATS_IN_MULTICAST_PKTS] = in_multicast_pkts_str;
+		// in-unicast-pkts
+		uint64_t in_unicast_pkts = nic_stats.rx_packets - nic_stats.rx_broadcast - in_multicast_pkts;
+		char in_unicast_pkts_str[32] = {0};
+		snprintf(in_unicast_pkts_str, sizeof(in_unicast_pkts_str), "%lu", in_unicast_pkts);
+		statistics[IF_STATS_IN_UNICAST_PKTS] = in_unicast_pkts_str;
+		// in-discards
+		char in_discards[32] = {0};
+		snprintf(in_discards, sizeof(in_discards), "%u", (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_RX_DROPPED));
+		statistics[IF_STATS_IN_DISCARDS] = in_discards;
+		// in-errors
+		char in_errors[32] = {0};
+		snprintf(in_errors, sizeof(in_errors), "%u", (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_RX_ERRORS));
+		statistics[IF_STATS_IN_ERRORS] = in_errors;
+		// in-unknown-protos
+		char in_unknown_protos[32] = {0};
+		snprintf(in_unknown_protos, sizeof(in_unknown_protos), "%u", (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_IP6_INUNKNOWNPROTOS));
+		statistics[IF_STATS_IN_UNKNOWN_PROTOS] = in_unknown_protos;
 
+		// Tx
+		// out-octets
+		char out_octets[32] = {0};
+		snprintf(out_octets, sizeof(out_octets), "%lu",rtnl_link_get_stat(link, RTNL_LINK_TX_BYTES));
+		statistics[IF_STATS_OUT_OCTETS] = out_octets;
+		// out-unicast-pkts
+		char out_unicast_pkts[32] = {0};
+		snprintf(out_unicast_pkts, sizeof(out_unicast_pkts), "%lu", nic_stats.tx_packets - nic_stats.tx_broadcast - nic_stats.tx_multicast);
+		statistics[IF_STATS_OUT_UNICAST_PKTS] = out_unicast_pkts;
+		// out-broadcast-pkts
+		char out_broadcast_pkts[32] = {0};
+		snprintf(out_broadcast_pkts, sizeof(out_broadcast_pkts), "%lu", nic_stats.tx_broadcast);
+		statistics[IF_STATS_OUT_BROADCAST_PKTS] = out_broadcast_pkts;
+		// out-multicast-pkts
+		char out_multicast_pkts[32] = {0};
+		snprintf(out_multicast_pkts, sizeof(out_multicast_pkts), "%lu", nic_stats.tx_multicast);
+		statistics[IF_STATS_OUT_MULTICAST_PKTS] = out_multicast_pkts;
+		// out-discards
+		char out_discards[32] = {0};
+		snprintf(out_discards, sizeof(out_discards), "%u", (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_TX_DROPPED));
+		statistics[IF_STATS_OUT_DISCARDS] = out_discards;
+		// out-errors
+		char out_errors[32] = {0};
+		snprintf(out_errors, sizeof(out_errors), "%u", (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_TX_ERRORS));
+		statistics[IF_STATS_OUT_ERRORS] = out_errors;
+
+		error = ds_oper_set_interface_statistics(*parent, ly_ctx, interface_data.name, statistics);
+		if (error) {
+			SRP_LOG_ERR("ds_oper_set_interface_statistics error");
+			goto error_out;
+		}
 
 		// higher-layer-if
 		for (uint64_t i = 0; i < master_list.count; i++) {
@@ -2974,121 +3020,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 			}
 		}
 
-		// stats:
-		// discontinuity-time
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/discontinuity-time", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRP_LOG_DBG("%s = %s", xpath_buffer, interface_data.statistics.discontinuity_time);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, interface_data.statistics.discontinuity_time, LYD_ANYDATA_STRING, 0);
-
-		// in-octets
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-octets", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.in_octets);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// in-unicast-pkts
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-unicast-pkts", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.in_unicast_pkts);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// in-broadcast-pkts
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-broadcast-pkts", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.in_broadcast_pkts);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// in-multicast-pkts
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-multicast-pkts", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.in_multicast_pkts);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// in-discards
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-discards", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", interface_data.statistics.in_discards);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// in-errors
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-errors", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", interface_data.statistics.in_errors);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// in-unknown-protos
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/in-unknown-protos", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", interface_data.statistics.in_unknown_protos);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// out-octets
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/out-octets", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.out_octets);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// out-unicast-pkts
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/out-unicast-pkts", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.out_unicast_pkts);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// out-broadcast-pkts
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/out-broadcast-pkts", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.out_broadcast_pkts);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// out-multicast-pkts
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/out-multicast-pkts", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.statistics.out_multicast_pkts);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// out-discards
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/out-discards", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", interface_data.statistics.out_discards);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// out-errors
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/statistics/out-errors", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", interface_data.statistics.out_errors);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
 		// free all allocated data
-		FREE_SAFE(interface_data.phys_address);
 
 		// continue to next link node
 		link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -72,7 +72,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, const char *modul
 
 // helper functions
 static bool system_running_datastore_is_empty_check(sr_session_ctx_t *session);
-static int load_data(sr_session_ctx_t *session, link_data_list_t *ld);
+static int fill_datastore_interface_list(sr_session_ctx_t *session, link_data_list_t *ld);
 static int load_startup(sr_session_ctx_t *session, link_data_list_t *ld);
 static char *interfaces_xpath_get(const struct lyd_node *node);
 static bool check_system_interface(const char *interface_name, bool *system_interface);
@@ -156,9 +156,9 @@ int sr_plugin_init_cb(sr_session_ctx_t *session, void **private_data)
 	if (system_running_datastore_is_empty_check(session) == true) {
 		SRP_LOG_INF("running DS is empty, loading data");
 
-		error = load_data(session, &link_data_list);
+		error = fill_datastore_interface_list(session, &link_data_list);
 		if (error) {
-			SRP_LOG_ERRMSG("load_data error");
+			SRP_LOG_ERRMSG("fill_datastore_interface_list error");
 			goto error_out;
 		}
 
@@ -238,7 +238,7 @@ out:
 	return is_empty;
 }
 
-static int load_data(sr_session_ctx_t *session, link_data_list_t *ld)
+static int fill_datastore_interface_list(sr_session_ctx_t *session, link_data_list_t *ld)
 {
 	int error = 0;
 	for (int i = 0; i < ld->count; i++) {
@@ -259,7 +259,7 @@ static int load_data(sr_session_ctx_t *session, link_data_list_t *ld)
 		} else if (strcmp(type, "dummy") == 0) {
 			interface_leaf_values[IF_TYPE] = "iana-if-type:other"; // since dummy is not a real type
 		} else {
-			SRP_LOG_INF("load_data unsupported interface type %s", type);
+			SRP_LOG_INF("fill_datastore_interface_list unsupported interface type %s", type);
 			continue;
 		}
 


### PR DESCRIPTION
Create functions for updating the datastore interface configuration in `datastore.c`.
Refactor `load_data` and rename it to `fill_datastore_interface_list`.
Refactor the state data callback `interfaces_state_data_cb`.