### PR TITLE
interfaces-plugin: refactor (devel)

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     ip_data.c
     ipv6_data.c
     if_nic_stats.c
+    datastore.c
     ${CMAKE_SOURCE_DIR}/src/utils/memory.c
 )
 

--- a/src/interfaces/datastore.c
+++ b/src/interfaces/datastore.c
@@ -38,7 +38,7 @@ static int ds_set_leaf_values(sr_session_ctx_t *session, char *base_xpath, char 
 			continue;
 		}
 		error = snprintf(xpath, sizeof(xpath), "%s/%s", base_xpath, leaf_names[i]);
-		if (error < 0) {
+		if (error < 0 || error >= PATH_MAX) {
 			SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 			goto out;
 		}
@@ -69,7 +69,7 @@ int ds_set_general_interface_config(sr_session_ctx_t *session, char *interface_n
 	char base_xpath[PATH_MAX] = {0};
 	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]",
 			 INTERFACE_LIST_YANG_PATH, interface_name);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -96,7 +96,7 @@ int ds_set_interface_ip_config(sr_session_ctx_t *session, char *interface_name, 
 	char base_xpath[PATH_MAX] = {0};
 	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:%s",
 			 INTERFACE_LIST_YANG_PATH, interface_name, ip_version);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -134,7 +134,7 @@ int ds_add_interface_ipv4_address(sr_session_ctx_t *session, char *interface_nam
 	char base_xpath[PATH_MAX] = {0};
 	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv4/address[ip='%s']",
 			 INTERFACE_LIST_YANG_PATH, interface_name, ip);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -159,7 +159,7 @@ int ds_add_interface_ipv4_neighbor(sr_session_ctx_t *session, char *interface_na
 	char base_xpath[PATH_MAX] = {0};
 	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv4/neighbor[ip='%s']",
 			 INTERFACE_LIST_YANG_PATH, interface_name, neigh_ip);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -185,7 +185,7 @@ int ds_add_interface_ipv6_address(sr_session_ctx_t *session, char *interface_nam
 	char base_xpath[PATH_MAX] = {0};
 	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv6/address[ip='%s']",
 			 INTERFACE_LIST_YANG_PATH, interface_name, ip);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -212,7 +212,7 @@ int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_na
 	char base_xpath[PATH_MAX] = {0};
 	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv6/neighbor[ip='%s']",
 			 INTERFACE_LIST_YANG_PATH, interface_name, neigh_ip);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -245,7 +245,7 @@ int ds_oper_set_interface_info(struct lyd_node *parent, const struct ly_ctx *ly_
 		char xpath[PATH_MAX] = {0};
 		error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/%s", INTERFACE_LIST_YANG_PATH,
 				 interface_name, interface_oper_info_leaf_names[i]);
-		if (error < 0) {
+		if (error < 0 || error >= PATH_MAX) {
 			SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 			goto out;
 		}
@@ -268,7 +268,7 @@ int ds_oper_add_interface_higher_layer_if(struct lyd_node *parent, const struct 
 	char xpath[PATH_MAX] = {0};
 	error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/higher-layer-if",
 			 INTERFACE_LIST_YANG_PATH, interface_name);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -289,7 +289,7 @@ int ds_oper_add_interface_lower_layer_if(struct lyd_node *parent, const struct l
 	char xpath[PATH_MAX] = {0};
 	error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/lower-layer-if",
 			 INTERFACE_LIST_YANG_PATH, interface_name);
-	if (error < 0) {
+	if (error < 0 || error >= PATH_MAX) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 		goto out;
 	}
@@ -331,7 +331,7 @@ int ds_oper_set_interface_statistics(struct lyd_node *parent, const struct ly_ct
 		char xpath[PATH_MAX] = {0};
 		error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/statistics/%s", INTERFACE_LIST_YANG_PATH,
 				 interface_name, interface_statistics_leaf_names[i]);
-		if (error < 0) {
+		if (error < 0 || error >= PATH_MAX) {
 			SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
 			goto out;
 		}

--- a/src/interfaces/datastore.c
+++ b/src/interfaces/datastore.c
@@ -1,0 +1,224 @@
+/*
+ * telekom / sysrepo-plugin-interfaces
+ *
+ * This program is made available under the terms of the
+ * BSD 3-Clause license which is available at
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * SPDX-FileCopyrightText: 2021 Deutsche Telekom AG
+ * SPDX-FileContributor: Sartura Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <linux/limits.h>
+#include <stdbool.h>
+
+#include <sysrepo.h>
+
+#include "datastore.h"
+
+/*
+ * Set the value of multiple YANG module leafs. The path for each leaf node is determined
+ * by concatenating base_xpath with its name from leaf_names. All leaf nodes with a non-NULL
+ * entry in leaf_values will be set.
+ */
+static int ds_set_leaf_values(sr_session_ctx_t *session, char *base_xpath, char **leaf_names,
+			      uint32_t leaf_count, char **leaf_values, bool log_changes)
+{
+	int error = SR_ERR_OK;
+	char xpath[PATH_MAX] = {0};
+
+	for (uint32_t i = 0; i < leaf_count; i++) {
+		if (leaf_values[i] == NULL) {
+			continue;
+		}
+		error = snprintf(xpath, sizeof(xpath), "%s/%s", base_xpath, leaf_names[i]);
+		if (error < 0) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+			goto out;
+		}
+		error = sr_set_item_str(session, xpath, leaf_values[i], NULL, SR_EDIT_DEFAULT);
+		if (error) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
+			goto out;
+		}
+		if (log_changes) {
+			SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath, leaf_values[i]);
+		}
+	}
+out:
+	return error;
+}
+
+static char *interface_leaf_names[IF_LEAF_COUNT] = {
+	[IF_TYPE] = "type",
+	[IF_DESCRIPTION] = "description",
+	[IF_ENABLED] = "enabled",
+	[IF_PARENT_INTERFACE] = "ietf-if-extensions:parent-interface"
+};
+
+int ds_set_general_interface_config(sr_session_ctx_t *session, char *interface_name,
+				    char *leaf_values[IF_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]",
+			 INTERFACE_LIST_YANG_PATH, interface_name);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_leaf_names,
+				   IF_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+/* Leaf nodes defined for both ipv4 and ipv6 */
+static char *interface_ip_leaf_names[IF_IP_LEAF_COUNT] = {
+	[IF_IP_ENABLED] = "enabled",
+	[IF_IP_FORWARDING] = "forwarding",
+	[IF_IP_MTU] = "mtu"
+};
+
+int ds_set_interface_ip_config(sr_session_ctx_t *session, char *interface_name, char *ip_version,
+			       char *leaf_values[IF_IP_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:%s",
+			 INTERFACE_LIST_YANG_PATH, interface_name, ip_version);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ip_leaf_names,
+				   IF_IP_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+int ds_set_interface_ipv4_config(sr_session_ctx_t *session, char *interface_name,
+				 char *leaf_values[IF_IP_LEAF_COUNT])
+{
+	return ds_set_interface_ip_config(session, interface_name, "ipv4", leaf_values);
+}
+
+int ds_set_interface_ipv6_config(sr_session_ctx_t *session, char *interface_name,
+				 char *leaf_values[IF_IP_LEAF_COUNT])
+{
+	return ds_set_interface_ip_config(session, interface_name, "ipv6", leaf_values);
+}
+
+static char *interface_ipv4_addr_leaf_names[IF_IPV4_ADDR_LEAF_COUNT] = {
+	[IF_IPV4_ADDR_SUBNET] = "subnet",
+	[IF_IPV4_ADDR_PREFIX_LENGTH] = "prefix-length",
+	[IF_IPV4_ADDR_ORIGIN] = "origin"
+};
+
+int ds_add_interface_ipv4_address(sr_session_ctx_t *session, char *interface_name,
+				  char *ip, char *leaf_values[IF_IPV4_ADDR_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv4/address[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, ip);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv4_addr_leaf_names,
+				   IF_IPV4_ADDR_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_ipv4_neigh_leaf_names[IF_IPV4_NEIGH_LEAF_COUNT] = {
+	[IF_IPV4_NEIGH_LINK_LAYER_ADDR] = "link-layer-address",
+	[IF_IPV4_NEIGH_ORIGIN] = "origin"
+};
+
+int ds_add_interface_ipv4_neighbor(sr_session_ctx_t *session, char *interface_name,
+				   char *neigh_ip, char *leaf_values[IF_IPV4_NEIGH_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv4/neighbor[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, neigh_ip);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv4_neigh_leaf_names,
+				   IF_IPV4_NEIGH_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_ipv6_addr_leaf_names[IF_IPV6_ADDR_LEAF_COUNT] = {
+	[IF_IPV6_ADDR_PREFIX_LENGTH] = "prefix-length",
+	[IF_IPV6_ADDR_ORIGIN] = "origin",
+	[IF_IPV6_ADDR_STATUS] = "status"
+};
+
+int ds_add_interface_ipv6_address(sr_session_ctx_t *session, char *interface_name,
+				  char *ip, char *leaf_values[IF_IPV6_ADDR_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv6/address[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, ip);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv6_addr_leaf_names,
+				   IF_IPV6_ADDR_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_ipv6_neigh_leaf_names[IF_IPV6_NEIGH_LEAF_COUNT] = {
+	[IF_IPV6_NEIGH_LINK_LAYER_ADDR] = "link-layer-address",
+	[IF_IPV6_NEIGH_ORIGIN] = "origin",
+	[IF_IPV6_NEIGH_IS_ROUTER] = "is-router",
+	[IF_IPV6_NEIGH_STATE] = "state"
+};
+
+int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_name,
+				   char *neigh_ip, char *leaf_values[IF_IPV6_NEIGH_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	char base_xpath[PATH_MAX] = {0};
+	error = snprintf(base_xpath, sizeof(base_xpath), "%s[name=\"%s\"]/ietf-ip:ipv6/neighbor[ip='%s']",
+			 INTERFACE_LIST_YANG_PATH, interface_name, neigh_ip);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = ds_set_leaf_values(session, base_xpath, interface_ipv6_neigh_leaf_names,
+				   IF_IPV6_NEIGH_LEAF_COUNT, leaf_values, true);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}

--- a/src/interfaces/datastore.c
+++ b/src/interfaces/datastore.c
@@ -17,6 +17,8 @@
 #include <stdbool.h>
 
 #include <sysrepo.h>
+#include <libyang/libyang.h>
+#include <libyang/tree_data.h>
 
 #include "datastore.h"
 
@@ -218,6 +220,128 @@ int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_na
 				   IF_IPV6_NEIGH_LEAF_COUNT, leaf_values, true);
 	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_leaf_values error");
+	}
+out:
+	return error;
+}
+
+static char *interface_oper_info_leaf_names[IF_OPER_LEAF_COUNT] = {
+	[IF_ADMIN_STATUS] = "admin-status",
+	[IF_OPER_STATUS] = "oper-status",
+	[IF_LAST_CHANGE] = "last-change",
+	[IF_IF_INDEX] = "if-index",
+	[IF_PHYS_ADDRESS] = "phys-address",
+	[IF_SPEED] = "speed"
+};
+
+int ds_oper_set_interface_info(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name,
+			       char *leaf_values[IF_OPER_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	for (uint32_t i = 0; i < IF_OPER_LEAF_COUNT; i++) {
+		if (leaf_values[i] == NULL) {
+			continue;
+		}
+		char xpath[PATH_MAX] = {0};
+		error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/%s", INTERFACE_LIST_YANG_PATH,
+				 interface_name, interface_oper_info_leaf_names[i]);
+		if (error < 0) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+			goto out;
+		}
+		error = 0;
+		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath, leaf_values[i]);
+		error = lyd_new_path(parent, ly_ctx, xpath, leaf_values[i], LYD_ANYDATA_STRING, NULL);
+		if (error) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "lyd_new_path error (%d)", error);
+			goto out;
+		}
+	}
+out:
+	return error;
+}
+
+int ds_oper_add_interface_higher_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx,
+					  char *interface_name, char *higher_layer_if)
+{
+	int error = SR_ERR_OK;
+	char xpath[PATH_MAX] = {0};
+	error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/higher-layer-if",
+			 INTERFACE_LIST_YANG_PATH, interface_name);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = 0;
+	SRPLG_LOG_DBG(PLUGIN_NAME, "%s += %s", xpath, higher_layer_if);
+	error = lyd_new_path(parent, ly_ctx, xpath, higher_layer_if, LYD_ANYDATA_STRING, NULL);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "lyd_new_path error (%d)", error);
+	}
+out:
+	return error;
+}
+
+int ds_oper_add_interface_lower_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx,
+					 char *interface_name, char *lower_layer_if)
+{
+	int error = SR_ERR_OK;
+	char xpath[PATH_MAX] = {0};
+	error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/lower-layer-if",
+			 INTERFACE_LIST_YANG_PATH, interface_name);
+	if (error < 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+		goto out;
+	}
+	error = 0;
+	SRPLG_LOG_DBG(PLUGIN_NAME, "%s += %s", xpath, lower_layer_if);
+	error = lyd_new_path(parent, ly_ctx, xpath, lower_layer_if, LYD_ANYDATA_STRING, NULL);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "lyd_new_path error (%d)", error);
+	}
+out:
+	return error;
+}
+
+static char *interface_statistics_leaf_names[IF_STATS_LEAF_COUNT] = {
+	[IF_STATS_DISCONTINUITY_TIME] = "discontinuity-time",
+	[IF_STATS_IN_OCTETS] = "in-octets",
+	[IF_STATS_IN_UNICAST_PKTS] = "in-unicast-pkts",
+	[IF_STATS_IN_BROADCAST_PKTS] = "in-broadcast-pkts",
+	[IF_STATS_IN_MULTICAST_PKTS] = "in-multicast-pkts",
+	[IF_STATS_IN_DISCARDS] = "in-discards",
+	[IF_STATS_IN_ERRORS] = "in-errors",
+	[IF_STATS_IN_UNKNOWN_PROTOS] = "in-unknown-protos",
+	[IF_STATS_OUT_OCTETS] = "out-octets",
+	[IF_STATS_OUT_UNICAST_PKTS] = "out-unicast-pkts",
+	[IF_STATS_OUT_BROADCAST_PKTS] = "out-broadcast-pkts",
+	[IF_STATS_OUT_MULTICAST_PKTS] = "out-multicast-pkts",
+	[IF_STATS_OUT_DISCARDS] = "out-discards",
+	[IF_STATS_OUT_ERRORS] = "out-errors"
+};
+
+int ds_oper_set_interface_statistics(struct lyd_node *parent, const struct ly_ctx *ly_ctx,
+				     char *interface_name, char *leaf_values[IF_STATS_LEAF_COUNT])
+{
+	int error = SR_ERR_OK;
+	for (uint32_t i = 0; i < IF_STATS_LEAF_COUNT; i++) {
+		if (leaf_values[i] == NULL) {
+			continue;
+		}
+		char xpath[PATH_MAX] = {0};
+		error = snprintf(xpath, sizeof(xpath), "%s[name=\"%s\"]/statistics/%s", INTERFACE_LIST_YANG_PATH,
+				 interface_name, interface_statistics_leaf_names[i]);
+		if (error < 0) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error (%d): %s", error, strerror(error));
+			goto out;
+		}
+		error = 0;
+		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath, leaf_values[i]);
+		error = lyd_new_path(parent, ly_ctx, xpath, leaf_values[i], LYD_ANYDATA_STRING, NULL);
+		if (error) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "lyd_new_path error (%d)", error);
+			goto out;
+		}
 	}
 out:
 	return error;

--- a/src/interfaces/datastore.h
+++ b/src/interfaces/datastore.h
@@ -79,4 +79,39 @@ enum interface_ipv6_neighbour_leaf {
 
 int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_name, char *neigh_ip, char *leaf_values[IF_IPV6_NEIGH_LEAF_COUNT]);
 
+enum interface_oper_info_leaf {
+	IF_ADMIN_STATUS,
+	IF_OPER_STATUS,
+	IF_LAST_CHANGE,
+	IF_IF_INDEX,
+	IF_PHYS_ADDRESS,
+	IF_SPEED,
+	IF_OPER_LEAF_COUNT
+};
+
+int ds_oper_set_interface_info(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *leaf_values[IF_OPER_LEAF_COUNT]);
+
+int ds_oper_add_interface_higher_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *higher_layer_if);
+int ds_oper_add_interface_lower_layer_if(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *lower_layer_if);
+
+enum interface_statistics_leaf {
+	IF_STATS_DISCONTINUITY_TIME,
+	IF_STATS_IN_OCTETS,
+	IF_STATS_IN_UNICAST_PKTS,
+	IF_STATS_IN_BROADCAST_PKTS,
+	IF_STATS_IN_MULTICAST_PKTS,
+	IF_STATS_IN_DISCARDS,
+	IF_STATS_IN_ERRORS,
+	IF_STATS_IN_UNKNOWN_PROTOS,
+	IF_STATS_OUT_OCTETS,
+	IF_STATS_OUT_UNICAST_PKTS,
+	IF_STATS_OUT_BROADCAST_PKTS,
+	IF_STATS_OUT_MULTICAST_PKTS,
+	IF_STATS_OUT_DISCARDS,
+	IF_STATS_OUT_ERRORS,
+	IF_STATS_LEAF_COUNT
+};
+
+int ds_oper_set_interface_statistics(struct lyd_node *parent, const struct ly_ctx *ly_ctx, char *interface_name, char *leaf_values[IF_STATS_LEAF_COUNT]);
+
 #endif // DATASTORE_H_ONCE

--- a/src/interfaces/datastore.h
+++ b/src/interfaces/datastore.h
@@ -1,0 +1,82 @@
+/*
+ * telekom / sysrepo-plugin-interfaces
+ *
+ * This program is made available under the terms of the
+ * BSD 3-Clause license which is available at
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * SPDX-FileCopyrightText: 2021 Deutsche Telekom AG
+ * SPDX-FileContributor: Sartura Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DATASTORE_H_ONCE
+#define DATASTORE_H_ONCE
+
+#define PLUGIN_NAME "interfaces-plugin"
+
+#define BASE_YANG_MODEL "ietf-interfaces"
+#define BASE_IP_YANG_MODEL "ietf-ip"
+// config data
+#define INTERFACES_YANG_MODEL "/" BASE_YANG_MODEL ":interfaces"
+#define INTERFACE_LIST_YANG_PATH INTERFACES_YANG_MODEL "/interface"
+
+enum interface_general_leaf {
+	IF_TYPE = 0,
+	IF_DESCRIPTION,
+	IF_ENABLED,
+	IF_PARENT_INTERFACE,
+	IF_LEAF_COUNT
+};
+
+int ds_set_general_interface_config(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_LEAF_COUNT]);
+
+/* leaf nodes defined for both ipv4 and ipv6 */
+enum interface_ip_leaf {
+	IF_IP_ENABLED = 0,
+	IF_IP_FORWARDING,
+	IF_IP_MTU,
+	IF_IP_LEAF_COUNT
+};
+
+int ds_set_interface_ipv4_config(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IP_LEAF_COUNT]);
+int ds_set_interface_ipv6_config(sr_session_ctx_t *session, char *interface_name, char *leaf_values[IF_IP_LEAF_COUNT]);
+
+enum interface_ipv4_addr_leaf {
+	IF_IPV4_ADDR_SUBNET = 0,
+	IF_IPV4_ADDR_PREFIX_LENGTH,
+	IF_IPV4_ADDR_ORIGIN,
+	IF_IPV4_ADDR_LEAF_COUNT
+};
+
+int ds_add_interface_ipv4_address(sr_session_ctx_t *session, char *interface_name, char *ip, char *leaf_values[IF_IPV4_ADDR_LEAF_COUNT]);
+
+enum interface_ipv4_neighbour_leaf {
+	IF_IPV4_NEIGH_LINK_LAYER_ADDR = 0,
+	IF_IPV4_NEIGH_ORIGIN,
+	IF_IPV4_NEIGH_LEAF_COUNT
+};
+
+int ds_add_interface_ipv4_neighbor(sr_session_ctx_t *session, char *interface_name, char *neigh_ip, char *leaf_values[IF_IPV4_NEIGH_LEAF_COUNT]);
+
+enum interface_ipv6_addr_leaf {
+	IF_IPV6_ADDR_PREFIX_LENGTH = 0,
+	IF_IPV6_ADDR_ORIGIN,
+	IF_IPV6_ADDR_STATUS,
+	IF_IPV6_ADDR_LEAF_COUNT
+};
+
+int ds_add_interface_ipv6_address(sr_session_ctx_t *session, char *interface_name, char *ip, char *leaf_values[IF_IPV6_ADDR_LEAF_COUNT]);
+
+enum interface_ipv6_neighbour_leaf {
+	IF_IPV6_NEIGH_LINK_LAYER_ADDR = 0,
+	IF_IPV6_NEIGH_ORIGIN,
+	IF_IPV6_NEIGH_IS_ROUTER,
+	IF_IPV6_NEIGH_STATE,
+	IF_IPV6_NEIGH_LEAF_COUNT
+};
+
+int ds_add_interface_ipv6_neighbor(sr_session_ctx_t *session, char *interface_name, char *neigh_ip, char *leaf_values[IF_IPV6_NEIGH_LEAF_COUNT]);
+
+#endif // DATASTORE_H_ONCE

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -26,6 +26,7 @@
 #include <linux/if.h>
 #include <linux/if.h>
 #include <linux/if_addr.h>
+#include <linux/if_ether.h>
 #include <linux/ip.h>
 #include <linux/limits.h>
 
@@ -64,7 +65,6 @@
 #define CLASS_NET_LINE_LEN 1024
 #define ADDR_STR_BUF_SIZE 45 // max ip string length (15 for ipv4 and 45 for ipv6)
 #define MAX_IF_NAME_LEN IFNAMSIZ // 16 bytes
-#define CMD_LEN 1024
 
 // callbacks
 static int interfaces_module_change_cb(sr_session_ctx_t *session, uint32_t subscription_id, const char *module_name, const char *xpath, sr_event_t event, uint32_t request_id, void *private_data);
@@ -89,7 +89,7 @@ int update_link_info(link_data_list_t *ld, sr_change_oper_t operation);
 static char *convert_ianaiftype(char *iana_if_type);
 int add_existing_links(sr_session_ctx_t *session, link_data_list_t *ld);
 static int get_interface_description(sr_session_ctx_t *session, char *name, char **description);
-static int create_vlan_qinq(char *name, char *parent_interface, uint16_t outer_vlan_id, uint16_t second_vlan_id);
+static int create_vlan_qinq(struct nl_sock *socket, struct nl_cache *cache, char *second_vlan_name, char *name, char *parent_interface, uint16_t outer_vlan_id, uint16_t second_vlan_id);
 static int get_system_boot_time(char boot_datetime[]);
 
 // function to start all threads for each interface
@@ -1083,7 +1083,7 @@ int update_link_info(link_data_list_t *ld, sr_change_oper_t operation)
 					if_state_list_add(&if_state_changes, state, name);
 
 					// then create the interface with new parameters
-					create_vlan_qinq(name, parent_interface, outer_vlan_id, second_vlan_id);
+					create_vlan_qinq(socket, cache, second_vlan_name, name, parent_interface, outer_vlan_id, second_vlan_id);
 
 				} else if (second_vlan_id == 0) {
 					// normal vlan interface
@@ -1685,30 +1685,70 @@ static int remove_neighbors(ip_neighbor_list_t *nbor_list, struct nl_sock *socke
 	return 0;
 }
 
-static int create_vlan_qinq(char *name, char *parent_interface, uint16_t outer_vlan_id, uint16_t second_vlan_id)
+static int create_vlan_qinq(struct nl_sock *socket, struct nl_cache *cache, char *second_vlan_name, char *name, char *parent_interface, uint16_t outer_vlan_id, uint16_t second_vlan_id)
 {
 	int error = 0;
-	char cmd[CMD_LEN] = {0};
+	struct rtnl_link *outer_tag_link = rtnl_link_alloc();
+	struct rtnl_link *second_tag_link = rtnl_link_alloc();
 
-	// e.g.: # ip link add link eth0 name eth0.10 type vlan id 10 protocol 802.1ad
-	error = snprintf(cmd, sizeof(cmd), "ip link add link %s name %s type vlan id %d protocol 802.1ad", parent_interface, name, outer_vlan_id);
+	// create virtual link for outer tag
+	error = rtnl_link_set_type(outer_tag_link, "vlan");
 	if (error < 0) {
-		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error");
-		return -1;
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_set_type error (%d): %s", error, nl_geterror(error));
+		goto out;
+	}
+	rtnl_link_set_name(outer_tag_link, name);
+	// set parent interface
+	int master_index = rtnl_link_name2i(cache, parent_interface);
+	rtnl_link_set_link(outer_tag_link, master_index);
+	// set protocol to 802.1ad (QinQ)
+	error = rtnl_link_vlan_set_protocol(outer_tag_link, htons(ETH_P_8021AD));
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_vlan_set_protocol error (%d): %s", error, nl_geterror(error));
+	}
+	// set outer vlan id (s-tag)
+	error = rtnl_link_vlan_set_id(outer_tag_link, outer_vlan_id);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_vlan_set_id error (%d): %s", error, nl_geterror(error));
+	}
+	error = rtnl_link_add(socket, outer_tag_link, NLM_F_CREATE);
+	if (error != 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_add error (%d): %s", error, nl_geterror(error));
+		goto out;
 	}
 
-	error = system(cmd);
-
-	// e.g.: # ip link add link eth0.10 name eth0.10.20 type vlan id 20
-	error = snprintf(cmd, sizeof(cmd), "ip link add link %s name %s.%d type vlan id %d", name, name, second_vlan_id, second_vlan_id);
+	// create virtual link for second tag
+	error = rtnl_link_set_type(second_tag_link, "vlan");
 	if (error < 0) {
-		SRPLG_LOG_ERR(PLUGIN_NAME, "snprintf error");
-		return -1;
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_set_type error (%d): %s", error, nl_geterror(error));
+		goto out;
 	}
-
-	error = system(cmd);
-
-	return 0;
+	rtnl_link_set_name(second_tag_link, second_vlan_name);
+	// retrieve outer_tag_link struct from the kernel so that it contains the correct ifindex
+	rtnl_link_put(outer_tag_link);
+	outer_tag_link = NULL;
+	error = rtnl_link_get_kernel(socket, 0, name, &outer_tag_link);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_get_kernel error (%d): %s", error, nl_geterror(error));
+		goto out;
+	}
+	// set outer_tag_link as the parent of second_tag_link to ensure it
+	// will be deleted automatically when outer_tag_link is deleted
+	rtnl_link_set_link(second_tag_link, rtnl_link_get_ifindex(outer_tag_link));
+	// set second vlan id (c-tag)
+	error = rtnl_link_vlan_set_id(second_tag_link, second_vlan_id);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_vlan_set_id error (%d): %s", error, nl_geterror(error));
+	}
+	error = rtnl_link_add(socket, second_tag_link, NLM_F_CREATE);
+	if (error != 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_add error (%d): %s", error, nl_geterror(error));
+		goto out;
+	}
+out:
+	rtnl_link_put(outer_tag_link);
+	rtnl_link_put(second_tag_link);
+	return error;
 }
 
 static bool check_system_interface(const char *interface_name, bool *system_interface)

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2553,10 +2553,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 	struct rtnl_tc *tc = NULL;
 	struct rtnl_qdisc *qdisc = NULL;
 
-	int32_t tmp_if_index = 0;
-	uint64_t tmp_len = 0;
-	struct rtnl_link *tmp_link = NULL;
-
 	char tmp_buffer[PATH_MAX] = {0};
 	char xpath_buffer[PATH_MAX] = {0};
 	char interface_path_buffer[PATH_MAX] = {0};
@@ -2576,10 +2572,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 		struct tm *last_change;
 		int32_t if_index;
 		char *phys_address;
-		struct {
-			char *masters[LD_MAX_LINKS];
-			uint32_t count;
-		} higher_layer_if;
 		uint64_t speed;
 		struct {
 			char *discontinuity_time;
@@ -2598,32 +2590,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			uint32_t out_errors;
 		} statistics;
 	} interface_data = {0};
-
-	typedef struct {
-		char *slave_name;
-		char *master_names[LD_MAX_LINKS];
-		uint32_t count;
-	} master_t;
-
-	typedef struct {
-		master_t masters[LD_MAX_LINKS];
-		uint32_t count;
-	} master_list_t;
-
-	master_list_t master_list = {0};
-
-	typedef struct {
-		char *master_name;
-		char *slave_names[LD_MAX_LINKS];
-		uint32_t count;
-	} slave_t;
-
-	typedef struct {
-		slave_t slaves[LD_MAX_LINKS];
-		uint32_t count;
-	} slave_list_t;
-
-	slave_list_t slave_list = {0};
 
 	const char *OPER_STRING_MAP[] = {
 		[IF_OPER_UNKNOWN] = "unknown",
@@ -2659,85 +2625,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 	if (error != 0) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_alloc_cache error (%d): %s", error, nl_geterror(error));
 		goto error_out;
-	}
-
-	// collect all master interfaces
-	link = (struct rtnl_link *) nl_cache_get_first(cache);
-
-	while (link != NULL) {
-		char *slave_name = rtnl_link_get_name(link);
-
-		// higher-layer-if
-		tmp_if_index = rtnl_link_get_master(link);
-		while (tmp_if_index) {
-			tmp_link = rtnl_link_get(cache, tmp_if_index);
-
-			char *master_name = rtnl_link_get_name(tmp_link);
-
-			tmp_len = strlen(master_name);
-
-			interface_data.higher_layer_if.masters[interface_data.higher_layer_if.count] = xstrndup(master_name, tmp_len);
-
-			interface_data.higher_layer_if.count++;
-
-			tmp_if_index = rtnl_link_get_master(tmp_link);
-		}
-
-		if (interface_data.higher_layer_if.count > 0) {
-			for (uint64_t i = 0; i < interface_data.higher_layer_if.count; i++) {
-				char *master_name = interface_data.higher_layer_if.masters[i];
-
-				tmp_len = strlen(slave_name);
-				master_list.masters[master_list.count].slave_name = xstrndup(slave_name, tmp_len);
-
-				tmp_len = strlen(master_name);
-				master_list.masters[master_list.count].master_names[i] = xstrndup(master_name, tmp_len);
-			}
-
-			master_list.masters[master_list.count].count = interface_data.higher_layer_if.count;
-			master_list.count++;
-		}
-
-		// continue to next link node
-		link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);
-	}
-
-	// collect all slave interfaces
-	link = (struct rtnl_link *) nl_cache_get_first(cache);
-
-	while (link != NULL) {
-		// lower-layer-if
-		char *if_name = rtnl_link_get_name(link);
-
-		bool break_out = false;
-		for (uint64_t i = 0; i < master_list.count; i++) {
-			for (uint64_t j = 0; j < master_list.masters[i].count; j++) {
-				if (strcmp(master_list.masters[i].slave_name, master_list.masters[i].master_names[j]) == 0) {
-					continue;
-				}
-
-				if (strcmp(master_list.masters[i].master_names[j], if_name) == 0) {
-					SRPLG_LOG_DBG(PLUGIN_NAME, "Slave of interface %s: %s", if_name, master_list.masters[i].slave_name);
-
-					tmp_len = strlen(if_name);
-					slave_list.slaves[slave_list.count].master_name = xstrndup(if_name, tmp_len);
-
-					tmp_len = strlen(master_list.masters[i].slave_name);
-					slave_list.slaves[slave_list.count].slave_names[i] = xstrndup(master_list.masters[i].slave_name, tmp_len);
-
-					slave_list.slaves[slave_list.count].count++;
-
-					break_out = true;
-					break;
-				}
-			}
-			if (break_out) {
-				slave_list.count++;
-				break;
-			}
-		}
-		// continue to next link node
-		link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);
 	}
 
 	char system_boot_time[DATETIME_BUF_SIZE] = {0};
@@ -2883,38 +2770,27 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			goto error_out;
 		}
 
-		// higher-layer-if
-		for (uint64_t i = 0; i < master_list.count; i++) {
-			if (strcmp(interface_data.name, master_list.masters[i].slave_name) == 0) {
-				for (uint64_t j = 0; j < master_list.masters[i].count; j++) {
+		// find all interfaces which are layered on top of this interface
+		// and update the operational datastore accordingly
+		int32_t master_if_index = rtnl_link_get_master(link);
+		struct rtnl_link *master_link = NULL;
+		while (master_if_index) {
+			master_link = rtnl_link_get(cache, master_if_index);
+			char *master_name = rtnl_link_get_name(master_link);
 
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/higher-layer-if", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "%s += %s", xpath_buffer, master_list.masters[i].master_names[j]);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, master_list.masters[i].master_names[j], LYD_ANYDATA_STRING, 0);
-
-					FREE_SAFE(interface_data.higher_layer_if.masters[i]);
-				}
+			error = ds_oper_add_interface_higher_layer_if(*parent, ly_ctx, interface_data.name, master_name);
+			if (error) {
+				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_add_interface_higher_layer_if error");
+				goto error_out;
 			}
-		}
-
-		// lower-layer-if
-		for (uint64_t i = 0; i < slave_list.count; i++) {
-			if (strcmp(interface_data.name, slave_list.slaves[i].master_name) == 0) {
-				for (uint64_t j = 0; j < slave_list.slaves[i].count; j++) {
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/lower-layer-if", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "%s += %s", xpath_buffer, slave_list.slaves[i].slave_names[j]);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, slave_list.slaves[i].slave_names[j], LYD_ANYDATA_STRING, 0);
-				}
+			error = ds_oper_add_interface_lower_layer_if(*parent, ly_ctx, master_name, interface_data.name);
+			if (error) {
+				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_add_interface_lower_layer_if error");
+				goto error_out;
 			}
+
+			// go one layer higher
+			master_if_index = rtnl_link_get_master(master_link);
 		}
 
 		// ietf-ip
@@ -3129,20 +3005,6 @@ error_out:
 	error = SR_ERR_CALLBACK_FAILED;
 
 out:
-	for (uint64_t i = 0; i < master_list.count; i++) {
-		for (uint64_t j = 0; j < master_list.masters[i].count; j++) {
-			FREE_SAFE(master_list.masters[i].master_names[j]);
-		}
-		FREE_SAFE(master_list.masters[i].slave_name);
-	}
-
-	for (uint64_t i = 0; i < slave_list.count; i++) {
-		for (uint64_t j = 0; j < slave_list.slaves[i].count; j++) {
-			FREE_SAFE(slave_list.slaves[i].slave_names[j]);
-		}
-		FREE_SAFE(slave_list.slaves[i].master_name);
-	}
-
 	nl_socket_free(socket);
 	return error ? SR_ERR_CALLBACK_FAILED : SR_ERR_OK;
 }

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -72,7 +72,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 
 // helper functions
 static bool system_running_datastore_is_empty_check(sr_session_ctx_t *session);
-static int load_data(sr_session_ctx_t *session, link_data_list_t *ld);
+static int fill_datastore_interface_list(sr_session_ctx_t *session, link_data_list_t *ld);
 static int load_startup(sr_session_ctx_t *session, link_data_list_t *ld);
 static bool check_system_interface(const char *interface_name, bool *system_interface);
 int set_config_value(const char *xpath, const char *value);
@@ -155,9 +155,9 @@ int sr_plugin_init_cb(sr_session_ctx_t *session, void **private_data)
 	if (system_running_datastore_is_empty_check(session) == true) {
 		SRPLG_LOG_INF(PLUGIN_NAME, "running DS is empty, loading data");
 
-		error = load_data(session, &link_data_list);
+		error = fill_datastore_interface_list(session, &link_data_list);
 		if (error) {
-			SRPLG_LOG_ERR(PLUGIN_NAME, "load_data error");
+			SRPLG_LOG_ERR(PLUGIN_NAME, "fill_datastore_interface_list error");
 			goto error_out;
 		}
 
@@ -237,7 +237,7 @@ out:
 	return is_empty;
 }
 
-static int load_data(sr_session_ctx_t *session, link_data_list_t *ld)
+static int fill_datastore_interface_list(sr_session_ctx_t *session, link_data_list_t *ld)
 {
 	int error = 0;
 	for (int i = 0; i < ld->count; i++) {
@@ -260,7 +260,7 @@ static int load_data(sr_session_ctx_t *session, link_data_list_t *ld)
 		} else if (strcmp(type, "dummy") == 0) {
 			interface_leaf_values[IF_TYPE] = "iana-if-type:other"; // since dummy is not a real type
 		} else {
-			SRPLG_LOG_INF(PLUGIN_NAME, "load_data unsupported interface type %s", type);
+			SRPLG_LOG_INF(PLUGIN_NAME, "fill_datastore_interface_list unsupported interface type %s", type);
 			continue;
 		}
 

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2740,6 +2740,13 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 		link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);
 	}
 
+	char system_boot_time[DATETIME_BUF_SIZE] = {0};
+	error = get_system_boot_time(system_boot_time);
+	if (error != 0) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "get_system_boot_time error: %s", strerror(errno));
+		goto error_out;
+	}
+
 	link = (struct rtnl_link *) nl_cache_get_first(cache);
 	qdisc = rtnl_qdisc_alloc();
 
@@ -2750,45 +2757,53 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 
 		interface_data.name = rtnl_link_get_name(link);
 
-		link_data_t *l = data_list_get_by_name(&link_data_list, interface_data.name);
-		if (l != NULL) {
-			interface_data.description = l->description;
-		}
+		// collect operational state information
+		char *interface_oper_leaf_values[IF_OPER_LEAF_COUNT] = {NULL};
 
-		interface_data.type = rtnl_link_get_type(link);
-		interface_data.enabled = rtnl_link_get_operstate(link) == IF_OPER_UP ? "enabled" : "disabled";
-	
 		// interface_data.link_up_down_trap_enable = ?
 		// interface_data.admin_status = ?
-		interface_data.oper_status = OPER_STRING_MAP[rtnl_link_get_operstate(link)];
-		interface_data.if_index = rtnl_link_get_ifindex(link);
 
-		// last-change field
+		// oper-status
+		interface_oper_leaf_values[IF_OPER_STATUS] = (char *) OPER_STRING_MAP[rtnl_link_get_operstate(link)];
+
+		// last-change
 		tmp_ifs = if_state_list_get_by_if_name(&if_state_changes, interface_data.name);
 		interface_data.last_change = (tmp_ifs->last_change != 0) ? localtime(&tmp_ifs->last_change) : NULL;
-
-		// get_system_boot_time will change the struct tm which is held in interface_data.last_change if it's not NULL
-		char system_time[DATETIME_BUF_SIZE] = {0};
+		char last_change_time[DATETIME_BUF_SIZE] = {0};
+		// last-change -> only if changed at one point
 		if (interface_data.last_change != NULL) {
 			// convert it to human readable format here
-			strftime(system_time, sizeof system_time, "%FT%TZ", interface_data.last_change);
+			strftime(last_change_time, sizeof(last_change_time), "%FT%TZ", interface_data.last_change);
+			interface_oper_leaf_values[IF_LAST_CHANGE] = last_change_time;
+		} else {
+			// default value of last-change should be system boot time
+			interface_oper_leaf_values[IF_LAST_CHANGE] = system_boot_time;
 		}
 
-		// mac address
+		// if-index
+		char if_index[16] = {0};
+		snprintf(if_index, sizeof(if_index), "%u", rtnl_link_get_ifindex(link));
+		interface_oper_leaf_values[IF_IF_INDEX] = if_index;
+
+		// phys-address
 		addr = rtnl_link_get_addr(link);
-		interface_data.phys_address = xmalloc(sizeof(char) * (MAC_ADDR_MAX_LENGTH + 1));
-		nl_addr2str(addr, interface_data.phys_address, MAC_ADDR_MAX_LENGTH);
-		interface_data.phys_address[MAC_ADDR_MAX_LENGTH] = 0;
+		char phys_address[MAC_ADDR_MAX_LENGTH + 1] = {0};
+		nl_addr2str(addr, phys_address, MAC_ADDR_MAX_LENGTH + 1);
+		phys_address[MAC_ADDR_MAX_LENGTH] = 0;
+		interface_oper_leaf_values[IF_PHYS_ADDRESS] = phys_address;
 
-		interface_data.speed = rtnl_tc_get_stat(tc, RTNL_TC_RATE_BPS);
+		// speed
+		char speed[32] = {0};
+		snprintf(speed, sizeof(speed), "%lu", rtnl_tc_get_stat(tc, RTNL_TC_RATE_BPS));
+		interface_oper_leaf_values[IF_SPEED] = speed;
 
-		// stats:
-		char system_boot_time[DATETIME_BUF_SIZE] = {0};
-		error = get_system_boot_time(system_boot_time);
-		if (error != 0) {
-			SRPLG_LOG_ERR(PLUGIN_NAME, "get_system_boot_time error: %s", strerror(errno));
+		error = ds_oper_set_interface_info(*parent, ly_ctx, interface_data.name, interface_oper_leaf_values);
+		if (error) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_set_interface_info error");
 			goto error_out;
 		}
+
+		// stats:
 		interface_data.statistics.discontinuity_time = system_boot_time;
 
 		// gather interface statistics that are not accessable via netlink
@@ -2819,81 +2834,8 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 
 		snprintf(interface_path_buffer, sizeof(interface_path_buffer) / sizeof(char), "%s[name=\"%s\"]", INTERFACE_LIST_YANG_PATH, rtnl_link_get_name(link));
 
-		// name
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/name", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.name);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, interface_data.name, LYD_ANYDATA_STRING, 0);
 
-		// description
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/description", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.description);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, interface_data.description, LYD_ANYDATA_STRING, 0);
 
-		// type
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/type", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.type);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, interface_data.type, LYD_ANYDATA_STRING, 0);
-
-		// oper-status
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/oper-status", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.oper_status);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, (char *) interface_data.oper_status, LYD_ANYDATA_STRING, 0);
-
-		// last-change -> only if changed at one point
-		if (interface_data.last_change != NULL) {
-			error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/last-change", interface_path_buffer);
-			if (error < 0) {
-				goto error_out;
-			}
-			SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.type);
-			lyd_new_path(*parent, ly_ctx, xpath_buffer, system_time, LYD_ANYDATA_STRING, 0);
-		} else {
-			// default value of last-change should be system boot time
-			error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/last-change", interface_path_buffer);
-			if (error < 0) {
-				goto error_out;
-			}
-			SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.type);
-			lyd_new_path(*parent, ly_ctx, xpath_buffer, system_boot_time, LYD_ANYDATA_STRING, 0);
-		}
-
-		// if-index
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/if-index", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %d", xpath_buffer, interface_data.if_index);
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", interface_data.if_index);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-
-		// phys-address
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/phys-address", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.phys_address);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, interface_data.phys_address, LYD_ANYDATA_STRING, 0);
-
-		// speed
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/speed", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-		SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, interface_data.speed);
-		snprintf(tmp_buffer, sizeof(tmp_buffer), "%lu", interface_data.speed);
-		lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
 
 		// higher-layer-if
 		for (uint64_t i = 0; i < master_list.count; i++) {
@@ -3014,7 +2956,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv4.nbor_list.nbor[j].phys_addr, LYD_ANYDATA_STRING, 0);
 
 							// neighbor-origin
-							error = create_node_neighbor_origin(parent, ly_ctx, xpath_buffer, interface_path_buffer, socket, interface_data.if_index, ip_addr, AF_INET);
+							error = create_node_neighbor_origin(parent, ly_ctx, xpath_buffer, interface_path_buffer, socket, rtnl_link_get_ifindex(link), ip_addr, AF_INET);
 							if (error < 0) {
 								goto error_out;
 							}
@@ -3114,7 +3056,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].phys_addr, LYD_ANYDATA_STRING, 0);
 
 							// neighbor-origin
-							error = create_node_neighbor_origin(parent, ly_ctx, xpath_buffer, interface_path_buffer, socket, interface_data.if_index, ip_addr, AF_INET6);
+							error = create_node_neighbor_origin(parent, ly_ctx, xpath_buffer, interface_path_buffer, socket, rtnl_link_get_ifindex(link), ip_addr, AF_INET6);
 							if (error < 0) {
 								goto error_out;
 							}

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2555,38 +2555,8 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 	struct nl_addr *addr = NULL;
 	struct rtnl_tc *tc = NULL;
 	struct rtnl_qdisc *qdisc = NULL;
-
 	if_state_t *tmp_ifs = NULL;
-
-	struct {
-		char *name;
-		char *description;
-		char *type;
-		char *enabled;
-		char *link_up_down_trap_enable;
-		char *admin_status;
-		const char *oper_status;
-		struct tm *last_change;
-		int32_t if_index;
-		char *phys_address;
-		uint64_t speed;
-		struct {
-			char *discontinuity_time;
-			uint64_t in_octets;
-			uint64_t in_unicast_pkts;
-			uint64_t in_broadcast_pkts;
-			uint64_t in_multicast_pkts;
-			uint32_t in_discards;
-			uint32_t in_errors;
-			uint32_t in_unknown_protos;
-			uint64_t out_octets;
-			uint64_t out_unicast_pkts;
-			uint64_t out_broadcast_pkts;
-			uint64_t out_multicast_pkts;
-			uint32_t out_discards;
-			uint32_t out_errors;
-		} statistics;
-	} interface_data = {0};
+	struct tm *last_change = NULL;
 
 	const char *OPER_STRING_MAP[] = {
 		[IF_OPER_UNKNOWN] = "unknown",
@@ -2639,7 +2609,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 		tc = TC_CAST(qdisc);
 		rtnl_tc_set_link(tc, link);
 
-		interface_data.name = rtnl_link_get_name(link);
+		char *interface_name = rtnl_link_get_name(link);
 
 		// collect operational state information
 		char *interface_oper_leaf_values[IF_OPER_LEAF_COUNT] = {NULL};
@@ -2651,13 +2621,13 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 		interface_oper_leaf_values[IF_OPER_STATUS] = (char *) OPER_STRING_MAP[rtnl_link_get_operstate(link)];
 
 		// last-change
-		tmp_ifs = if_state_list_get_by_if_name(&if_state_changes, interface_data.name);
-		interface_data.last_change = (tmp_ifs->last_change != 0) ? localtime(&tmp_ifs->last_change) : NULL;
+		tmp_ifs = if_state_list_get_by_if_name(&if_state_changes, interface_name);
+		last_change = (tmp_ifs->last_change != 0) ? localtime(&tmp_ifs->last_change) : NULL;
 		char last_change_time[DATETIME_BUF_SIZE] = {0};
 		// last-change -> only if changed at one point
-		if (interface_data.last_change != NULL) {
+		if (last_change != NULL) {
 			// convert it to human readable format here
-			strftime(last_change_time, sizeof(last_change_time), "%FT%TZ", interface_data.last_change);
+			strftime(last_change_time, sizeof(last_change_time), "%FT%TZ", last_change);
 			interface_oper_leaf_values[IF_LAST_CHANGE] = last_change_time;
 		} else {
 			// default value of last-change should be system boot time
@@ -2682,7 +2652,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 		interface_oper_leaf_values[IF_SPEED] = speed;
 
 		// set interface state info in operational ds
-		error = ds_oper_set_interface_info(*parent, ly_ctx, interface_data.name, interface_oper_leaf_values);
+		error = ds_oper_set_interface_info(*parent, ly_ctx, interface_name, interface_oper_leaf_values);
 		if (error) {
 			SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_set_interface_info error");
 			goto error_out;
@@ -2693,7 +2663,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 
 		// gather interface statistics that are not accessable via netlink
 		nic_stats_t nic_stats = {0};
-		error = get_nic_stats(interface_data.name, &nic_stats);
+		error = get_nic_stats(interface_name, &nic_stats);
 		if (error != 0) {
 			SRPLG_LOG_ERR(PLUGIN_NAME, "get_nic_stats error: %s", strerror(errno));
 		}
@@ -2759,7 +2729,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 		snprintf(out_errors, sizeof(out_errors), "%u", (uint32_t) rtnl_link_get_stat(link, RTNL_LINK_TX_ERRORS));
 		statistics[IF_STATS_OUT_ERRORS] = out_errors;
 
-		error = ds_oper_set_interface_statistics(*parent, ly_ctx, interface_data.name, statistics);
+		error = ds_oper_set_interface_statistics(*parent, ly_ctx, interface_name, statistics);
 		if (error) {
 			SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_set_interface_statistics error");
 			goto error_out;
@@ -2773,12 +2743,12 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			master_link = rtnl_link_get(cache, master_if_index);
 			char *master_name = rtnl_link_get_name(master_link);
 
-			error = ds_oper_add_interface_higher_layer_if(*parent, ly_ctx, interface_data.name, master_name);
+			error = ds_oper_add_interface_higher_layer_if(*parent, ly_ctx, interface_name, master_name);
 			if (error) {
 				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_add_interface_higher_layer_if error");
 				goto error_out;
 			}
-			error = ds_oper_add_interface_lower_layer_if(*parent, ly_ctx, master_name, interface_data.name);
+			error = ds_oper_add_interface_lower_layer_if(*parent, ly_ctx, master_name, interface_name);
 			if (error) {
 				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_oper_add_interface_lower_layer_if error");
 				goto error_out;
@@ -2788,13 +2758,13 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			master_if_index = rtnl_link_get_master(master_link);
 		}
 
-		link_data_t *l = data_list_get_by_name(&link_data_list, interface_data.name);
+		link_data_t *l = data_list_get_by_name(&link_data_list, interface_name);
 		if (l != NULL) {
 			// set origin for ipv4 neighbors
 			uint32_t ipv4_neigh_count = l->ipv4.nbor_list.count;
 			for (uint32_t i = 0; i < ipv4_neigh_count; i++) {
 				char *neigh_ip = l->ipv4.nbor_list.nbor[i].ip;
-				error = create_node_neighbor_origin(parent, ly_ctx, interface_data.name, socket, rtnl_link_get_ifindex(link), neigh_ip, AF_INET);
+				error = create_node_neighbor_origin(parent, ly_ctx, interface_name, socket, rtnl_link_get_ifindex(link), neigh_ip, AF_INET);
 				if (error < 0) {
 					SRPLG_LOG_ERR(PLUGIN_NAME, "create_node_neighbor_origin error (ipv4)");
 					goto error_out;
@@ -2804,7 +2774,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			uint32_t ipv6_neigh_count = l->ipv6.ip_data.nbor_list.count;
 			for (uint32_t i = 0; i < ipv6_neigh_count; i++) {
 				char *neigh_ip = l->ipv6.ip_data.nbor_list.nbor[i].ip;
-				error = create_node_neighbor_origin(parent, ly_ctx, interface_data.name, socket, rtnl_link_get_ifindex(link), neigh_ip, AF_INET6);
+				error = create_node_neighbor_origin(parent, ly_ctx, interface_name, socket, rtnl_link_get_ifindex(link), neigh_ip, AF_INET6);
 				if (error < 0) {
 					SRPLG_LOG_ERR(PLUGIN_NAME, "create_node_neighbor_origin error (ipv6)");
 					goto error_out;

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2473,12 +2473,13 @@ error_out:
  * @returns:
  *      0 on successful neighbor-origin node creation, -1 on error
  */
-int create_node_neighbor_origin(struct lyd_node **parent, const struct ly_ctx *ly_ctx, char xpath_buffer[PATH_MAX], char interface_path_buffer[PATH_MAX], 
+int create_node_neighbor_origin(struct lyd_node **parent, const struct ly_ctx *ly_ctx, char *interface_name,
 				struct nl_sock *socket, int32_t if_index, char *ip_addr, int family)
 {
 	struct nl_cache *cache = NULL;
 	struct nl_addr *dst_addr = NULL;
 	struct rtnl_neigh *neigh = NULL;
+	char xpath_buffer[PATH_MAX];
 
 	int state = -1;
 	char *origin = NULL;
@@ -2511,8 +2512,8 @@ int create_node_neighbor_origin(struct lyd_node **parent, const struct ly_ctx *l
 	// NUD_PERMANENT signifies a static entry
 	origin = state & NUD_PERMANENT ? "static" : "dynamic";
 
-	error = snprintf(xpath_buffer, PATH_MAX, "%s/ietf-ip:ipv%u/neighbor[ip='%s']/origin", 
-			 interface_path_buffer, family == AF_INET6 ? 6 : 4, ip_addr);
+	error = snprintf(xpath_buffer, PATH_MAX, "%s[name=\"%s\"]/ietf-ip:ipv%u/neighbor[ip='%s']/origin", 
+			 INTERFACE_LIST_YANG_PATH, interface_name, family == AF_INET6 ? 6 : 4, ip_addr);
 	// null character not counted in written chars, therefore greater or equal than
 	if (error < 0 || error >= PATH_MAX) {
 		goto error;
@@ -2526,8 +2527,11 @@ int create_node_neighbor_origin(struct lyd_node **parent, const struct ly_ctx *l
 
 	SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, origin);
 	rc = 0;
+	goto out;
 
 error:
+	SRPLG_LOG_ERR(PLUGIN_NAME, "create_node_neighbor_origin failed for address %s", ip_addr);
+out:
 	if (cache != NULL) {
 		nl_cache_free(cache);
 	}
@@ -2537,7 +2541,6 @@ error:
 	if (neigh) {
 		rtnl_neigh_put(neigh);
 	}
-	SRPLG_LOG_ERR(PLUGIN_NAME, "create_node_neighbor_origin failed for address %s", ip_addr);
 
 	return rc;
 }
@@ -2553,13 +2556,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 	struct rtnl_tc *tc = NULL;
 	struct rtnl_qdisc *qdisc = NULL;
 
-	char tmp_buffer[PATH_MAX] = {0};
-	char xpath_buffer[PATH_MAX] = {0};
-	char interface_path_buffer[PATH_MAX] = {0};
-
 	if_state_t *tmp_ifs = NULL;
-
-	unsigned int mtu = 0;
 
 	struct {
 		char *name;
@@ -2701,8 +2698,6 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			SRPLG_LOG_ERR(PLUGIN_NAME, "get_nic_stats error: %s", strerror(errno));
 		}
 
-		snprintf(interface_path_buffer, sizeof(interface_path_buffer) / sizeof(char), "%s[name=\"%s\"]", INTERFACE_LIST_YANG_PATH, rtnl_link_get_name(link));
-
 		// discontinuity-time
 		statistics[IF_STATS_DISCONTINUITY_TIME] =  system_boot_time;
 
@@ -2793,197 +2788,26 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 			master_if_index = rtnl_link_get_master(master_link);
 		}
 
-		// ietf-ip
-		// mtu
-		mtu = rtnl_link_get_mtu(link);
-
-		// list of ipv4 addresses
-		for (uint32_t i = 0; i < link_data_list.count; i++) {
-			if (link_data_list.links[i].name != NULL) { // in case we deleted a link it will be NULL
-				if (strcmp(link_data_list.links[i].name, interface_data.name ) == 0) {
-
-					// enabled
-					// TODO
-
-					// forwarding
-					uint8_t ipv4_forwarding = link_data_list.links[i].ipv4.forwarding;
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/forwarding", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %d", xpath_buffer, ipv4_forwarding);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, ipv4_forwarding == 0 ? "false" : "true", LYD_ANYDATA_STRING, 0);
-
-					uint32_t ipv4_addr_count = link_data_list.links[i].ipv4.addr_list.count;
-
-					for (uint32_t j = 0; j < ipv4_addr_count; j++) {
-						if (link_data_list.links[i].ipv4.addr_list.addr[j].ip != NULL) { // in case we deleted an ip address it will be NULL
-							char *ip_addr = link_data_list.links[i].ipv4.addr_list.addr[j].ip;
-
-							if (mtu > 0) {
-								error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/mtu", interface_path_buffer);
-								if (error < 0) {
-									goto error_out;
-								}
-								snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", mtu);
-								SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, tmp_buffer);
-								lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-							}
-
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/address[ip='%s']/ip", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-							// ip
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, link_data_list.links[i].ipv4.addr_list.addr[j].ip);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv4.addr_list.addr[j].ip, LYD_ANYDATA_STRING, 0);
-
-							// subnet
-							snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", link_data_list.links[i].ipv4.addr_list.addr[j].subnet);
-
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/address[ip='%s']/prefix-length", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, tmp_buffer);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-						}
-					}
-
-					// neighbors
-					uint32_t ipv4_neigh_count = link_data_list.links[i].ipv4.nbor_list.count;
-
-					for (uint32_t j = 0; j < ipv4_neigh_count; j++) {
-						if (link_data_list.links[i].ipv4.nbor_list.nbor[j].ip != NULL) { // in case we deleted an ip address it will be NULL
-							char *ip_addr = link_data_list.links[i].ipv4.nbor_list.nbor[j].ip;
-
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/neighbor[ip='%s']/ip", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-							// ip
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, link_data_list.links[i].ipv4.nbor_list.nbor[j].ip);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv4.nbor_list.nbor[j].ip, LYD_ANYDATA_STRING, 0);
-
-							// link-layer-address
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/neighbor[ip='%s']/link-layer-address", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, link_data_list.links[i].ipv4.nbor_list.nbor[j].phys_addr);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv4.nbor_list.nbor[j].phys_addr, LYD_ANYDATA_STRING, 0);
-
-							// neighbor-origin
-							error = create_node_neighbor_origin(parent, ly_ctx, xpath_buffer, interface_path_buffer, socket, rtnl_link_get_ifindex(link), ip_addr, AF_INET);
-							if (error < 0) {
-								goto error_out;
-							}
-						}
-					}
+		link_data_t *l = data_list_get_by_name(&link_data_list, interface_data.name);
+		if (l != NULL) {
+			// set origin for ipv4 neighbors
+			uint32_t ipv4_neigh_count = l->ipv4.nbor_list.count;
+			for (uint32_t i = 0; i < ipv4_neigh_count; i++) {
+				char *neigh_ip = l->ipv4.nbor_list.nbor[i].ip;
+				error = create_node_neighbor_origin(parent, ly_ctx, interface_data.name, socket, rtnl_link_get_ifindex(link), neigh_ip, AF_INET);
+				if (error < 0) {
+					SRPLG_LOG_ERR(PLUGIN_NAME, "create_node_neighbor_origin error (ipv4)");
+					goto error_out;
 				}
 			}
-		}
-
-		// list of ipv6 addresses
-		for (uint32_t i = 0; i < link_data_list.count; i++) {
-			if (link_data_list.links[i].name != NULL) { // in case we deleted a link it will be NULL
-				if (strcmp(link_data_list.links[i].name, interface_data.name ) == 0) {
-
-					// enabled
-					uint8_t ipv6_enabled = link_data_list.links[i].ipv6.ip_data.enabled;
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/enabled", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %d", xpath_buffer, ipv6_enabled);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, ipv6_enabled == 0 ? "false" : "true", LYD_ANYDATA_STRING, 0);
-
-					// forwarding
-					uint8_t ipv6_forwarding = link_data_list.links[i].ipv6.ip_data.forwarding;
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/forwarding", interface_path_buffer);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %d", xpath_buffer, ipv6_forwarding);
-					lyd_new_path(*parent, ly_ctx, xpath_buffer, ipv6_forwarding == 0 ? "false" : "true", LYD_ANYDATA_STRING, 0);
-
-					uint32_t ipv6_addr_count = link_data_list.links[i].ipv6.ip_data.addr_list.count;
-
-					for (uint32_t j = 0; j < ipv6_addr_count; j++) {
-						if (link_data_list.links[i].ipv6.ip_data.addr_list.addr[j].ip != NULL) { // in case we deleted an ip address it will be NULL
-							char *ip_addr = link_data_list.links[i].ipv6.ip_data.addr_list.addr[j].ip;
-
-							// mtu
-							if (mtu > 0 && ip_addr != NULL) {
-								error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/mtu", interface_path_buffer);
-								if (error < 0) {
-									goto error_out;
-								}
-								snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", mtu);
-								SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, tmp_buffer);
-								lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-							}
-
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/address[ip='%s']/ip", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-							// ip
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, link_data_list.links[i].ipv6.ip_data.addr_list.addr[j].ip);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv6.ip_data.addr_list.addr[j].ip, LYD_ANYDATA_STRING, 0);
-
-							// subnet
-							snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", link_data_list.links[i].ipv6.ip_data.addr_list.addr[j].subnet);
-
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/address[ip='%s']/prefix-length", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, tmp_buffer);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, tmp_buffer, LYD_ANYDATA_STRING, 0);
-						}
-					}
-
-					// neighbors
-					uint32_t ipv6_neigh_count = link_data_list.links[i].ipv6.ip_data.nbor_list.count;
-
-					for (uint32_t j = 0; j < ipv6_neigh_count; j++) {
-						if (link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].ip != NULL) { // in case we deleted an ip address it will be NULL
-							char *ip_addr = link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].ip;
-
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/neighbor[ip='%s']/ip", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-							// ip
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].ip);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].ip, LYD_ANYDATA_STRING, 0);
-
-							// link-layer-address
-							error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/neighbor[ip='%s']/link-layer-address", interface_path_buffer, ip_addr);
-							if (error < 0) {
-								goto error_out;
-							}
-
-							SRPLG_LOG_DBG(PLUGIN_NAME, "%s = %s", xpath_buffer, link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].phys_addr);
-							lyd_new_path(*parent, ly_ctx, xpath_buffer, link_data_list.links[i].ipv6.ip_data.nbor_list.nbor[j].phys_addr, LYD_ANYDATA_STRING, 0);
-
-							// neighbor-origin
-							error = create_node_neighbor_origin(parent, ly_ctx, xpath_buffer, interface_path_buffer, socket, rtnl_link_get_ifindex(link), ip_addr, AF_INET6);
-							if (error < 0) {
-								goto error_out;
-							}
-						}
-					}
+			// set origin for ipv6 neighbors
+			uint32_t ipv6_neigh_count = l->ipv6.ip_data.nbor_list.count;
+			for (uint32_t i = 0; i < ipv6_neigh_count; i++) {
+				char *neigh_ip = l->ipv6.ip_data.nbor_list.nbor[i].ip;
+				error = create_node_neighbor_origin(parent, ly_ctx, interface_data.name, socket, rtnl_link_get_ifindex(link), neigh_ip, AF_INET6);
+				if (error < 0) {
+					SRPLG_LOG_ERR(PLUGIN_NAME, "create_node_neighbor_origin error (ipv6)");
+					goto error_out;
 				}
 			}
 		}

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -54,15 +54,8 @@
 #include "ip_data.h"
 #include "link_data.h"
 #include "utils/memory.h"
+#include "datastore.h"
 
-#define BASE_YANG_MODEL "ietf-interfaces"
-#define BASE_IP_YANG_MODEL "ietf-ip"
-
-// config data
-#define INTERFACES_YANG_MODEL "/" BASE_YANG_MODEL ":interfaces"
-#define INTERFACE_LIST_YANG_PATH INTERFACES_YANG_MODEL "/interface"
-
-#define PLUGIN_NAME "interfaces-plugin"
 
 // other #defines
 #define MAC_ADDR_MAX_LENGTH 18
@@ -247,324 +240,138 @@ out:
 static int load_data(sr_session_ctx_t *session, link_data_list_t *ld)
 {
 	int error = 0;
-	char interface_path_buffer[PATH_MAX] = {0};
-	char xpath_buffer[PATH_MAX] = {0};
-	char tmp_buffer[PATH_MAX] = {0};
-
 	for (int i = 0; i < ld->count; i++) {
-		char *name = ld->links[i].name;
-		char *type = ld->links[i].type;
-		char *description = ld->links[i].description;
-		char *enabled = ld->links[i].enabled;
-		char *parent_interface = ld->links[i].extensions.parent_interface;
+		link_data_t *link = &ld->links[i];
 
-		snprintf(interface_path_buffer, sizeof(interface_path_buffer) / sizeof(char), "%s[name=\"%s\"]", INTERFACE_LIST_YANG_PATH, name);
-
+		// general interface config
+		char *interface_leaf_values[IF_LEAF_COUNT] = {NULL};
+		interface_leaf_values[IF_DESCRIPTION] = link->description != NULL ? ld->links[i].description : "";
+		interface_leaf_values[IF_ENABLED] = link->enabled;
+		interface_leaf_values[IF_PARENT_INTERFACE] = link->extensions.parent_interface;
+		char *type = link->type;
 		if (strcmp(type, "lo") == 0) {
-			type = "iana-if-type:softwareLoopback";
+			interface_leaf_values[IF_TYPE] = "iana-if-type:softwareLoopback";
 		} else if (strcmp(type, "eth") == 0) {
-			type = "iana-if-type:ethernetCsmacd";
+			interface_leaf_values[IF_TYPE] = "iana-if-type:ethernetCsmacd";
 		} else if (strcmp(type, "vlan") == 0) {
-			type = "iana-if-type:l2vlan";
+			interface_leaf_values[IF_TYPE] = "iana-if-type:l2vlan";
 		}  else if (strcmp(type, "bridge") == 0) {
-			type = "iana-if-type:bridge";
+			interface_leaf_values[IF_TYPE] = "iana-if-type:bridge";
 		} else if (strcmp(type, "dummy") == 0) {
-			type = "iana-if-type:other"; // since dummy is not a real type
+			interface_leaf_values[IF_TYPE] = "iana-if-type:other"; // since dummy is not a real type
 		} else {
 			SRPLG_LOG_INF(PLUGIN_NAME, "load_data unsupported interface type %s", type);
 			continue;
 		}
 
-		error = sr_set_item_str(session, interface_path_buffer, name, NULL, SR_EDIT_DEFAULT);
+		error = ds_set_general_interface_config(session, link->name, interface_leaf_values);
 		if (error) {
-			SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
+			SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_interface_general_info error");
 			goto error_out;
 		}
 
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/description", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
+		// TODO: handle vlan interfaces
 
-		error = sr_set_item_str(session, xpath_buffer, description, NULL, SR_EDIT_DEFAULT);
+		// ipv4 config
+		char *ipv4_leaf_values[IF_IP_LEAF_COUNT] = {NULL};
+		ipv4_leaf_values[IF_IP_ENABLED] = link->ipv4.enabled == 0 ? "false" : "true";
+		ipv4_leaf_values[IF_IP_FORWARDING] = link->ipv4.forwarding == 0 ? "false" : "true";
+		char ipv4_mtu[16] = {0};
+		if (link->ipv4.mtu > 0) {
+			snprintf(ipv4_mtu, sizeof(ipv4_mtu), "%u", ld->links[i].ipv4.mtu);
+			ipv4_leaf_values[IF_IP_MTU] = ipv4_mtu;
+		}
+		error = ds_set_interface_ipv4_config(session, link->name, ipv4_leaf_values);
 		if (error) {
-			SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
+			SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_interface_ipv4_config error");
 			goto error_out;
 		}
 
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/type", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-
-		error = sr_set_item_str(session, xpath_buffer, type, NULL, SR_EDIT_DEFAULT);
-		if (error) {
-			SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-			goto error_out;
-		}
-
-		error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/enabled", interface_path_buffer);
-		if (error < 0) {
-			goto error_out;
-		}
-
-		error = sr_set_item_str(session, xpath_buffer, enabled, NULL, SR_EDIT_DEFAULT);
-		if (error) {
-			SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-			goto error_out;
-		}
-
-		if (parent_interface != 0) {
-			error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-if-extensions:parent-interface", interface_path_buffer);
-			if (error < 0) {
-				goto error_out;
-			}
-
-			error = sr_set_item_str(session, xpath_buffer, parent_interface, NULL, SR_EDIT_DEFAULT);
-			if (error) {
-				SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-				goto error_out;
-			}
-		}
-
-		// handle vlan interfaces
-
-
-		// ietf-ip
-		// TODO: refactor this!
 		// list of ipv4 addresses
-		if (strcmp(ld->links[i].name, name ) == 0) {
-			// enabled
-			// TODO
-
-			// forwarding
-			uint8_t ipv4_forwarding = ld->links[i].ipv4.forwarding;
-
-			error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/forwarding", interface_path_buffer);
-			if (error < 0) {
-				goto error_out;
+		uint32_t ipv4_addr_count = link->ipv4.addr_list.count;
+		for (uint32_t j = 0; j < ipv4_addr_count; j++) {
+			if (link->ipv4.addr_list.addr[j].ip == NULL) { // in case we deleted an ip address it will be NULL
+				continue;
 			}
+			ip_address_t *addr = &link->ipv4.addr_list.addr[j];
 
-			SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ipv4_forwarding == 0 ? "false" : "true");
+			char *ipv4_addr_leaf_values[IF_IPV4_ADDR_LEAF_COUNT] = {NULL};
+			char prefix_len[8] = {0};
+			snprintf(prefix_len, sizeof(prefix_len), "%u", addr->subnet);
+			ipv4_addr_leaf_values[IF_IPV4_ADDR_PREFIX_LENGTH] = prefix_len;
 
-			error = sr_set_item_str(session, xpath_buffer, ipv4_forwarding == 0 ? "false" : "true", NULL, SR_EDIT_DEFAULT);
+			error = ds_add_interface_ipv4_address(session, link->name, addr->ip, ipv4_addr_leaf_values);
 			if (error) {
-				SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
+				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_add_interface_ipv4_address error");
 				goto error_out;
 			}
+		}
 
-			uint32_t ipv4_addr_count = ld->links[i].ipv4.addr_list.count;
+		// list of ipv4 neighbors
+		uint32_t ipv4_neigh_count = link->ipv4.nbor_list.count;
+		for (uint32_t j = 0; j < ipv4_neigh_count; j++) {
+			ip_neighbor_t *neigh = &link->ipv4.nbor_list.nbor[j];
 
-			for (uint32_t j = 0; j < ipv4_addr_count; j++) {
-				if (ld->links[i].ipv4.addr_list.addr[j].ip != NULL) { // in case we deleted an ip address it will be NULL
-					char *ip_addr = ld->links[i].ipv4.addr_list.addr[j].ip;
+			char *ipv4_neigh_leaf_values[IF_IPV4_NEIGH_LEAF_COUNT] = {NULL};
+			ipv4_neigh_leaf_values[IF_IPV4_NEIGH_LINK_LAYER_ADDR] = neigh->phys_addr;
 
-					int ipv4_mtu = ld->links[i].ipv4.mtu;
-					if (ipv4_mtu > 0) {
-						error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/mtu", interface_path_buffer);
-						if (error < 0) {
-							goto error_out;
-						}
-
-						snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", ipv4_mtu);
-
-						SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, tmp_buffer);
-
-						error = sr_set_item_str(session, xpath_buffer, tmp_buffer, NULL, SR_EDIT_DEFAULT);
-						if (error) {
-							SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-							goto error_out;
-						}
-					}
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/address[ip='%s']", interface_path_buffer, ip_addr);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					// ip
-					SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ld->links[i].ipv4.addr_list.addr[j].ip);
-					error = sr_set_item_str(session, xpath_buffer, ld->links[i].ipv4.addr_list.addr[j].ip, NULL, SR_EDIT_DEFAULT);
-					if (error) {
-						SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-						goto error_out;
-					}
-
-					// subnet
-					snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", ld->links[i].ipv4.addr_list.addr[j].subnet);
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/address[ip='%s']/prefix-length", interface_path_buffer, ip_addr);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, tmp_buffer);
-
-					error = sr_set_item_str(session, xpath_buffer, tmp_buffer, NULL, SR_EDIT_DEFAULT);
-					if (error) {
-						SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-						goto error_out;
-					}
-				}
-			}
-
-			// list of ipv4 neighbors
-			uint32_t ipv4_neigh_count = ld->links[i].ipv4.nbor_list.count;
-			for (uint32_t j = 0; j < ipv4_neigh_count; j++) {
-				char *ip_addr = ld->links[i].ipv4.nbor_list.nbor[j].ip;
-
-				error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/neighbor[ip='%s']", interface_path_buffer, ip_addr);
-				if (error < 0) {
-					goto error_out;
-				}
-
-				// ip
-				SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ld->links[i].ipv4.nbor_list.nbor[j].ip);
-				error = sr_set_item_str(session, xpath_buffer, ld->links[i].ipv4.nbor_list.nbor[j].ip, NULL, SR_EDIT_DEFAULT);
-				if (error) {
-					SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-					goto error_out;
-				}
-
-				// link-layer-address
-				error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv4/neighbor[ip='%s']/link-layer-address", interface_path_buffer, ip_addr);
-				if (error < 0) {
-					goto error_out;
-				}
-
-				SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ld->links[i].ipv4.nbor_list.nbor[j].phys_addr);
-
-				error = sr_set_item_str(session, xpath_buffer, ld->links[i].ipv4.nbor_list.nbor[j].phys_addr, NULL, SR_EDIT_DEFAULT);
-				if (error) {
-					SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-					goto error_out;
-				}
-			}
-
-			// list of ipv6 addresses
-			// enabled
-			uint8_t ipv6_enabled = ld->links[i].ipv6.ip_data.enabled;
-
-			error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/enabled", interface_path_buffer);
-			if (error < 0) {
-				goto error_out;
-			}
-
-			SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ipv6_enabled == 0 ? "false" : "true");
-
-			error = sr_set_item_str(session, xpath_buffer, ipv6_enabled == 0 ? "false" : "true", NULL, SR_EDIT_DEFAULT);
+			error = ds_add_interface_ipv4_neighbor(session, link->name, neigh->ip, ipv4_neigh_leaf_values);
 			if (error) {
-				SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
+				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_add_interface_ipv4_neighbor error");
 				goto error_out;
 			}
+		}
 
-			// forwarding
-			uint8_t ipv6_forwarding = ld->links[i].ipv6.ip_data.forwarding;
+		// ipv6 config
+		char *ipv6_leaf_values[IF_IP_LEAF_COUNT] = {NULL};
+		ipv6_leaf_values[IF_IP_ENABLED] = link->ipv6.ip_data.enabled == 0 ? "false" : "true";
+		ipv6_leaf_values[IF_IP_FORWARDING] = link->ipv6.ip_data.forwarding == 0 ? "false" : "true";
+		char ipv6_mtu[16] = {0};
+		if (link->ipv6.ip_data.mtu > 0) {
+			snprintf(ipv6_mtu, sizeof(ipv6_mtu), "%u", ld->links[i].ipv6.ip_data.mtu);
+			ipv4_leaf_values[IF_IP_MTU] = ipv6_mtu;
+		}
+		error = ds_set_interface_ipv6_config(session, link->name, ipv6_leaf_values);
+		if (error) {
+			SRPLG_LOG_ERR(PLUGIN_NAME, "ds_set_interface_ipv6_config error");
+			goto error_out;
+		}
 
-			error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/forwarding", interface_path_buffer);
-			if (error < 0) {
-				goto error_out;
+		// list of ipv6 addresses
+		uint32_t ipv6_addr_count = link->ipv6.ip_data.addr_list.count;
+		for (uint32_t j = 0; j < ipv6_addr_count; j++) {
+			if (link->ipv6.ip_data.addr_list.addr[j].ip == NULL) { // in case we deleted an ip address it will be NULL
+				continue;
 			}
+			ip_address_t *addr = &link->ipv6.ip_data.addr_list.addr[j];
 
-			SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ipv6_forwarding == 0 ? "false" : "true");
+			char *ipv6_addr_leaf_values[IF_IPV6_ADDR_LEAF_COUNT] = {NULL};
+			char prefix_len[8] = {0};
+			snprintf(prefix_len, sizeof(prefix_len), "%u", addr->subnet);
+			ipv6_addr_leaf_values[IF_IPV6_ADDR_PREFIX_LENGTH] = prefix_len;
 
-			error = sr_set_item_str(session, xpath_buffer, ipv6_forwarding == 0 ? "false" : "true", NULL, SR_EDIT_DEFAULT);
+			error = ds_add_interface_ipv6_address(session, link->name, addr->ip, ipv6_addr_leaf_values);
 			if (error) {
-				SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
+				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_add_interface_ipv6_address error");
 				goto error_out;
 			}
+		}
 
-			uint32_t ipv6_addr_count = ld->links[i].ipv6.ip_data.addr_list.count;
+		// list of ipv6 neighbors
+		uint32_t ipv6_neigh_count = ld->links[i].ipv6.ip_data.nbor_list.count;
+		for (uint32_t j = 0; j < ipv6_neigh_count; j++) {
+			ip_neighbor_t *neigh = &link->ipv6.ip_data.nbor_list.nbor[j];
 
-			for (uint32_t j = 0; j < ipv6_addr_count; j++) {
-				if (ld->links[i].ipv6.ip_data.addr_list.addr[j].ip != NULL) { // in case we deleted an ip address it will be NULL
-					char *ip_addr = ld->links[i].ipv6.ip_data.addr_list.addr[j].ip;
-					int ipv6_mtu = ld->links[i].ipv6.ip_data.mtu;
+			char *ipv6_neigh_leaf_values[IF_IPV6_NEIGH_LEAF_COUNT] = {NULL};
+			ipv6_neigh_leaf_values[IF_IPV6_NEIGH_LINK_LAYER_ADDR] = neigh->phys_addr;
 
-					// mtu
-					if (ipv6_mtu > 0 && ip_addr != NULL) {
-						error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/mtu", interface_path_buffer);
-						if (error < 0) {
-							goto error_out;
-						}
-						snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", ipv6_mtu);
-
-						SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, tmp_buffer);
-
-						error = sr_set_item_str(session, xpath_buffer, tmp_buffer, NULL, SR_EDIT_DEFAULT);
-						if (error) {
-							SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-							goto error_out;
-						}
-					}
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/address[ip='%s']", interface_path_buffer, ip_addr);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					// ip
-					SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ld->links[i].ipv6.ip_data.addr_list.addr[j].ip);
-
-					error = sr_set_item_str(session, xpath_buffer, ld->links[i].ipv6.ip_data.addr_list.addr[j].ip, NULL, SR_EDIT_DEFAULT);
-					if (error) {
-						SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-						goto error_out;
-					}
-
-					// subnet
-					snprintf(tmp_buffer, sizeof(tmp_buffer), "%u", ld->links[i].ipv6.ip_data.addr_list.addr[j].subnet);
-
-					error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/address[ip='%s']/prefix-length", interface_path_buffer, ip_addr);
-					if (error < 0) {
-						goto error_out;
-					}
-
-					SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, tmp_buffer);
-
-					error = sr_set_item_str(session, xpath_buffer, tmp_buffer, NULL, SR_EDIT_DEFAULT);
-					if (error) {
-						SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-						goto error_out;
-					}
-				}
-			}
-
-			// list of ipv6 neighbors
-			uint32_t ipv6_neigh_count = ld->links[i].ipv6.ip_data.nbor_list.count;
-			for (uint32_t j = 0; j < ipv6_neigh_count; j++) {
-				char *ip_addr = ld->links[i].ipv6.ip_data.nbor_list.nbor[j].ip;
-
-				error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/neighbor[ip='%s']", interface_path_buffer, ip_addr);
-				if (error < 0) {
-					goto error_out;
-				}
-
-				// ip
-				SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ld->links[i].ipv6.ip_data.nbor_list.nbor[j].ip);
-				error = sr_set_item_str(session, xpath_buffer, ld->links[i].ipv6.ip_data.nbor_list.nbor[j].ip, NULL, SR_EDIT_DEFAULT);
-				if (error) {
-					SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-					goto error_out;
-				}
-
-				// link-layer-address
-				error = snprintf(xpath_buffer, sizeof(xpath_buffer), "%s/ietf-ip:ipv6/neighbor[ip='%s']/link-layer-address", interface_path_buffer, ip_addr);
-				if (error < 0) {
-					goto error_out;
-				}
-
-				SRPLG_LOG_DBG(PLUGIN_NAME, "xpath_buffer: %s = %s", xpath_buffer, ld->links[i].ipv6.ip_data.nbor_list.nbor[j].phys_addr);
-
-				error = sr_set_item_str(session, xpath_buffer, ld->links[i].ipv6.ip_data.nbor_list.nbor[j].phys_addr, NULL, SR_EDIT_DEFAULT);
-				if (error) {
-					SRPLG_LOG_ERR(PLUGIN_NAME, "sr_set_item_str error (%d): %s", error, sr_strerror(error));
-					goto error_out;
-				}
+			error = ds_add_interface_ipv6_neighbor(session, link->name, neigh->ip, ipv6_neigh_leaf_values);
+			if (error) {
+				SRPLG_LOG_ERR(PLUGIN_NAME, "ds_add_interface_ipv6_neighbor error");
+				goto error_out;
 			}
 		}
 	}
-
 	error = sr_apply_changes(session, 0);
 	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "sr_apply_changes error (%d): %s", error, sr_strerror(error));
@@ -2950,6 +2757,7 @@ static int interfaces_state_data_cb(sr_session_ctx_t *session, uint32_t subscrip
 
 		interface_data.type = rtnl_link_get_type(link);
 		interface_data.enabled = rtnl_link_get_operstate(link) == IF_OPER_UP ? "enabled" : "disabled";
+	
 		// interface_data.link_up_down_trap_enable = ?
 		// interface_data.admin_status = ?
 		interface_data.oper_status = OPER_STRING_MAP[rtnl_link_get_operstate(link)];

--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -1693,33 +1693,35 @@ static int create_vlan_qinq(struct nl_sock *socket, struct nl_cache *cache, char
 
 	// create virtual link for outer tag
 	error = rtnl_link_set_type(outer_tag_link, "vlan");
-	if (error < 0) {
+	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_set_type error (%d): %s", error, nl_geterror(error));
 		goto out;
 	}
 	rtnl_link_set_name(outer_tag_link, name);
 	// set parent interface
-	int master_index = rtnl_link_name2i(cache, parent_interface);
-	rtnl_link_set_link(outer_tag_link, master_index);
+	int parent_index = rtnl_link_name2i(cache, parent_interface);
+	rtnl_link_set_link(outer_tag_link, parent_index);
 	// set protocol to 802.1ad (QinQ)
 	error = rtnl_link_vlan_set_protocol(outer_tag_link, htons(ETH_P_8021AD));
 	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_vlan_set_protocol error (%d): %s", error, nl_geterror(error));
+		goto out;
 	}
 	// set outer vlan id (s-tag)
 	error = rtnl_link_vlan_set_id(outer_tag_link, outer_vlan_id);
 	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_vlan_set_id error (%d): %s", error, nl_geterror(error));
+		goto out;
 	}
 	error = rtnl_link_add(socket, outer_tag_link, NLM_F_CREATE);
-	if (error != 0) {
+	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_add error (%d): %s", error, nl_geterror(error));
 		goto out;
 	}
 
 	// create virtual link for second tag
 	error = rtnl_link_set_type(second_tag_link, "vlan");
-	if (error < 0) {
+	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_set_type error (%d): %s", error, nl_geterror(error));
 		goto out;
 	}
@@ -1739,9 +1741,10 @@ static int create_vlan_qinq(struct nl_sock *socket, struct nl_cache *cache, char
 	error = rtnl_link_vlan_set_id(second_tag_link, second_vlan_id);
 	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_vlan_set_id error (%d): %s", error, nl_geterror(error));
+		goto out;
 	}
 	error = rtnl_link_add(socket, second_tag_link, NLM_F_CREATE);
-	if (error != 0) {
+	if (error) {
 		SRPLG_LOG_ERR(PLUGIN_NAME, "rtnl_link_add error (%d): %s", error, nl_geterror(error));
 		goto out;
 	}


### PR DESCRIPTION
Create functions for updating the datastore interface configuration in `datastore.c`.
Refactor `load_data` and rename it to `fill_datastore_interface_list`.
Refactor the state data callback `interfaces_state_data_cb`.
Create QinQ vlan links with libnl functions instead of calling ip command.