### PR TITLE
Handle vlan interface names with no dot

### DIFF
--- a/src/interfaces/interfaces.c
+++ b/src/interfaces/interfaces.c
@@ -2105,7 +2105,9 @@ int add_existing_links(sr_session_ctx_t *session, link_data_list_t *ld)
 			char *second = NULL;
 
 			first = strchr(name, '.');
-			second = strchr(first + 1, '.');
+			if (first != 0) {
+				second = strchr(first + 1, '.');
+			}
 
 			if (second != 0) {
 				link = (struct rtnl_link *) nl_cache_get_next((struct nl_object *) link);


### PR DESCRIPTION
Small fix to avoid triggering a segfault when the name of a vlan interface does not contain a `.` character. Fixes https://github.com/telekom/sysrepo-plugin-interfaces/issues/41