### PR TITLE
Integration tests setup/teardown rework

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -65,6 +65,8 @@ OK
 ## Robot framework
 Note the root privileges when invoking the command (datastore permission issues otherwise, item not found):
 
+The plugin wait start time can be modified via the env var `SYSREPO_INTEGRATION_PLUGIN_TIMEOUT_SECONDS`. The default value is `0.5s`. It's set in `robot-ietf-interfaces/InterfacesInit.resource` and `robot-ietf-routing/RoutingInit.resource`.
+
 To test the interfaces plugin (change env var path):
 ```
 # SYSREPO_INTERFACES_PLUGIN_PATH=/path/to/interfaces/plugin/executable robot robot-ietf-interfaces

--- a/tests/integration/robot-ietf-interfaces/InterfaceInit.resource
+++ b/tests/integration/robot-ietf-interfaces/InterfaceInit.resource
@@ -5,6 +5,7 @@ Library             Process
 
 *** Variables ***
 ${Xpath Interfaces}     /ietf-interfaces:interfaces
+${Running Datastore}    running
 
 *** Keywords ***
 Restore Initial Running Datastore
@@ -19,3 +20,33 @@ Check If Datastore Is Restored
     ...    ${Xpath Interfaces}
     ...    json
     Should Be Equal As Strings    ${Restored}    ${If Init Str}    msg="failed to restore inital running datastore"
+
+Init Running Session
+    ${Session Running}=    Open Datastore Session    ${Connection Default}    ${Running Datastore}
+    Set Global Variable    ${Session Running}
+    ${If Init Str}=    Get Datastore Data
+    ...    ${Connection Default}
+    ...    ${Session Running}
+    ...    ${Xpath Interfaces}
+    ...    json
+    Set Global Variable    ${If Init Str}
+    &{If Init JSON}=    Convert String To JSON    ${If Init Str}
+    Set Global Variable    ${If Init JSON}
+
+Connect Interfaces
+    Start Plugin
+    ${Connection Default}=    Open Sysrepo Connection
+    Set Global Variable    ${Connection Default}
+    Init Running Session
+
+Cleanup Interfaces
+    Restore Initial Running Datastore
+    Cleanup IETF Interfaces
+
+Start Plugin
+    ${Plugin}=    Start Process    %{SYSREPO_INTERFACES_PLUGIN_PATH}
+    Set Global Variable    ${Plugin}
+    Wait For Process    ${Plugin}    timeout=0.1s    on_timeout=continue
+
+Cleanup IETF Interfaces
+    Terminate Process    ${Plugin}

--- a/tests/integration/robot-ietf-interfaces/InterfaceInit.resource
+++ b/tests/integration/robot-ietf-interfaces/InterfaceInit.resource
@@ -41,12 +41,12 @@ Connect Interfaces
 
 Cleanup Interfaces
     Restore Initial Running Datastore
-    Cleanup IETF Interfaces
+    Stop Plugin
 
 Start Plugin
     ${Plugin}=    Start Process    %{SYSREPO_INTERFACES_PLUGIN_PATH}
     Set Global Variable    ${Plugin}
     Wait For Process    ${Plugin}    timeout=0.1s    on_timeout=continue
 
-Cleanup IETF Interfaces
+Stop Plugin
     Terminate Process    ${Plugin}

--- a/tests/integration/robot-ietf-interfaces/InterfaceInit.resource
+++ b/tests/integration/robot-ietf-interfaces/InterfaceInit.resource
@@ -4,13 +4,15 @@ Library             RPA.JSON
 Library             Process
 
 *** Variables ***
-${Xpath Interfaces}     /ietf-interfaces:interfaces
-${Running Datastore}    running
+${Xpath Interfaces}                  /ietf-interfaces:interfaces
+${Running Datastore}                 running
+${Plugin Timeout Seconds Default}    0.5s
+${Plugin Timeout Seconds}            %{SYSREPO_INTEGRATION_PLUGIN_TIMEOUT_SECONDS=${Plugin Timeout Seconds Default}}
 
 *** Keywords ***
 Restore Initial Running Datastore
     Edit Datastore Config    ${Connection Default}    ${Session Running}    ${If Init Str}   json
-    Check If Datastore Is Restored
+    #Check If Datastore Is Restored
 
 Check If Datastore Is Restored
     [Documentation]     Make sure the initial datastore is restored
@@ -46,7 +48,7 @@ Cleanup Interfaces
 Start Plugin
     ${Plugin}=    Start Process    %{SYSREPO_INTERFACES_PLUGIN_PATH}
     Set Global Variable    ${Plugin}
-    Wait For Process    ${Plugin}    timeout=0.1s    on_timeout=continue
+    Wait For Process    ${Plugin}    timeout=${Plugin Timeout Seconds}    on_timeout=continue
 
 Stop Plugin
     Terminate Process    ${Plugin}

--- a/tests/integration/robot-ietf-interfaces/README.md
+++ b/tests/integration/robot-ietf-interfaces/README.md
@@ -2,8 +2,11 @@
 Robot framework tests via the Sysrepo robot library.
 
 ## `__init__.robot`
-Initializes a default Sysrepo connection as well as a running  datastore session at the start of each test.
-At the end of a test, the initial datastore data is restored as well as all connections and sessions being closed. 
+Starts the plugin, nitializes a default Sysrepo connection as well as a running  datastore session at the start of each test.
+At the end of a test, the initial datastore data is restored and check for success as well as all connections and sessions being closed. 
+
+## `InterfacesInit.resource`
+Contains all the keywords used for test setup/teardown in `__init__.robot`
 
 ## `InterfaceTests.robot`, `IpTests.robot`
 These files contain integration test cases

--- a/tests/integration/robot-ietf-interfaces/__init__.robot
+++ b/tests/integration/robot-ietf-interfaces/__init__.robot
@@ -4,42 +4,9 @@ Library             RPA.JSON
 Library             Process
 Resource            InterfaceInit.resource
 
-Suite Setup         Setup IETF Interfaces
+
 Suite Teardown      Cleanup IETF Interfaces
 
-Test Teardown       Restore Initial Running Datastore
+Test Setup	        Connect Interfaces
+Test Teardown       Cleanup Interfaces
 
-*** Variables ***
-${Xpath Interfaces}     /ietf-interfaces:interfaces
-${Running Datastore}    running
-
-
-*** Keywords ***
-Setup IETF Interfaces
-    [Documentation]    Create a default connection and running session
-    Start Plugin
-    ${Connection Default}=    Open Sysrepo Connection
-    Set Global Variable    ${Connection Default}
-    Init Running Session
-
-Start Plugin
-    ${Plugin}=    Start Process    %{SYSREPO_INTERFACES_PLUGIN_PATH}
-    Set Suite Variable    ${Plugin}
-    Wait For Process    ${Plugin}    timeout=2s    on_timeout=continue
-
-Init Running Session
-    ${Session Running}=    Open Datastore Session    ${Connection Default}    ${Running Datastore}
-    Set Global Variable    ${Session Running}
-    ${If Init Str}=    Get Datastore Data
-    ...    ${Connection Default}
-    ...    ${Session Running}
-    ...    ${Xpath Interfaces}
-    ...    json
-    Set Global Variable    ${If Init Str}
-    &{If Init JSON}=    Convert String To JSON    ${If Init Str}
-    Set Global Variable    ${If Init JSON}
-
-Cleanup IETF Interfaces
-    # Restore initial data
-    Terminate Process    ${Plugin}
-    Close All Sysrepo Connections And Sessions

--- a/tests/integration/robot-ietf-interfaces/__init__.robot
+++ b/tests/integration/robot-ietf-interfaces/__init__.robot
@@ -5,8 +5,6 @@ Library             Process
 Resource            InterfaceInit.resource
 
 
-Suite Teardown      Cleanup IETF Interfaces
-
-Test Setup	        Connect Interfaces
+Test Setup	    Connect Interfaces
 Test Teardown       Cleanup Interfaces
 

--- a/tests/integration/robot-ietf-routing/README.md
+++ b/tests/integration/robot-ietf-routing/README.md
@@ -2,8 +2,11 @@
 Robot framework tests via the Sysrepo robot library.
 
 ## `__init__.robot`
-Initializes a default Sysrepo connection as well as running and operational datastore sessions at the start of each test.
-At the end of a test, the initial datastore data is restored as well as all connections and sessions being closed. 
+Starts the plugin, initializes a default Sysrepo connection as well as running and operational datastore sessions at the start of each test.
+At the end of a test, the initial datastore data is restored and checked for success as well as all connections and sessions being closed. 
+
+## `RoutingInit.resource`
+Contains all the keywords used for test setup/teardown in `__init__.robot`
 
 ## `InterfaceTests.robot`, `RoutesTests.robot`, `StaticRoutesTests.robot`
 These files contain integration test cases

--- a/tests/integration/robot-ietf-routing/RoutingInit.resource
+++ b/tests/integration/robot-ietf-routing/RoutingInit.resource
@@ -6,7 +6,8 @@ Library             Process
 *** Variables ***
 ${Xpath Routing}            /ietf-routing:routing
 ${Running Datastore}        running
-${Plugin Timeout Seconds}   0.5s
+${Plugin Timeout Seconds Default}    0.5s
+${Plugin Timeout Seconds}            %{SYSREPO_INTEGRATION_PLUGIN_TIMEOUT_SECONDS=${Plugin Timeout Seconds Default}}
 
 *** Keywords ***
 Restore Initial Running Datastore

--- a/tests/integration/robot-ietf-routing/RoutingInit.resource
+++ b/tests/integration/robot-ietf-routing/RoutingInit.resource
@@ -5,10 +5,12 @@ Library             Process
 
 *** Variables ***
 ${Xpath Routing}            /ietf-routing:routing
+${Running Datastore}        running
+${Plugin Timeout Seconds}   0.5s
 
 *** Keywords ***
 Restore Initial Running Datastore
-    Edit Datastore Config    ${Connection Default}    ${Session Running}    ${Routing Init Running Str}   json
+    Edit Datastore Config    ${Connection Default}    ${Session Running}    ${Route Init Str}   json
     Check If Datastore Is Restored
 
 Check If Datastore Is Restored
@@ -18,4 +20,34 @@ Check If Datastore Is Restored
     ...    ${Session Running}
     ...    ${Xpath Routing}
     ...    json
-    Should Be Equal As Strings    ${Restored}    ${Routing Init Running Str}    msg="failed to restore inital running datastore"
+    Should Be Equal As Strings    ${Restored}    ${Route Init Str}    msg="failed to restore inital running datastore"
+
+Init Running Session
+    ${Session Running}=    Open Datastore Session    ${Connection Default}    ${Running Datastore}
+    Set Global Variable    ${Session Running}
+    ${Route Init Str}=    Get Datastore Data
+    ...    ${Connection Default}
+    ...    ${Session Running}
+    ...    ${Xpath Routing}
+    ...    json
+    Set Global Variable    ${Route Init Str}
+    &{Route Init JSON}=    Convert String To JSON    ${Route Init Str}
+    Set Global Variable    ${Route Init JSON}
+
+Connect Routing
+    Start Plugin
+    ${Connection Default}=    Open Sysrepo Connection
+    Set Global Variable    ${Connection Default}
+    Init Running Session
+
+Cleanup Routing
+    Restore Initial Running Datastore
+    Stop Plugin
+
+Start Plugin
+    ${Plugin}=    Start Process    %{SYSREPO_ROUTING_PLUGIN_PATH}
+    Set Global Variable    ${Plugin}
+    Wait For Process    ${Plugin}    timeout=${Plugin Timeout Seconds}    on_timeout=continue
+
+Stop Plugin
+    Terminate Process    ${Plugin}

--- a/tests/integration/robot-ietf-routing/__init__.robot
+++ b/tests/integration/robot-ietf-routing/__init__.robot
@@ -4,57 +4,7 @@ Library             RPA.JSON
 Library             Process
 Resource            RoutingInit.resource
 
-Suite Setup         Setup IETF Routing
-Suite Teardown      Cleanup IETF Routing
 
-Test Teardown       Restore Initial Running Datastore
-
-*** Variables ***
-${Xpath Routing}            /ietf-routing:routing
-${Operational Datastore}    operational
-${Running Datastore}        running 
-
-
-*** Keywords ***
-Setup IETF Routing
-    [Documentation]    Create a default connection and running and operational sessions
-    Start Plugin
-    ${Connection Default}=    Open Sysrepo Connection
-    Set Global Variable    ${Connection Default}
-    Init Running Session
-    Init Operational Session
-
-Start Plugin
-    ${Plugin}=    Start Process    %{SYSREPO_ROUTING_PLUGIN_PATH}
-    Set Suite Variable    ${Plugin}
-    Wait For Process    ${Plugin}    timeout=2s    on_timeout=continue
-
-Init Running Session
-    ${Session Running}=    Open Datastore Session    ${Connection Default}    ${Running Datastore}
-    Set Global Variable    ${Session Running}
-    ${Routing Init Running Str}=    Get Datastore Data
-    ...    ${Connection Default}
-    ...    ${Session RUnning}
-    ...    ${Xpath Routing}
-    ...    json
-    Set Global Variable    ${Routing Init Running Str}
-    &{Routing Init Running JSON}=    Convert String To JSON    ${Routing Init Running Str}
-    Set Global Variable    ${Routing Init Running JSON}
-
-Init Operational Session
-    ${Session Operational}=    Open Datastore Session    ${Connection Default}    ${Operational Datastore}
-    Set Global Variable    ${Session Operational}
-    ${Routing Init Operational Str}=    Get Datastore Data
-    ...    ${Connection Default}
-    ...    ${Session Operational}
-    ...    ${Xpath Routing}
-    ...    json
-    Set Global Variable    ${Routing Init Operational Str}
-    &{Routing Init Operational JSON}=    Convert String To JSON    ${Routing Init Operational Str}
-    Set Global Variable    ${Routing Init Operational JSON}
-
-Cleanup IETF Routing
-    [Documentation]    Restore initial running datastore
-    Terminate Process    ${Plugin}
-    Close All Sysrepo Connections And Sessions
+Test Setup	        Connect Routing
+Test Teardown       Cleanup Routing
 


### PR DESCRIPTION
- reworked the way setup/teardown start and stop the plugin
- the plugin now starts/stops per test not per suite - connection/session start/stop - full setup/cleanup
- added an environment variable for the plugin process startup timeout - default 0.5s
- updated integration test readmes