### PR TITLE
build(src): fix utils not being loaded on build

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PLUGIN_EXECUTABLE_NAME "ietf-interfaces-plugin")
 include_directories(
     ${CMAKE_SOURCE_DIR}/src/interfaces/src
     ${CMAKE_SOURCE_DIR}/deps/uthash
+    ${CMAKE_SOURCE_DIR}/src/utils
 )
 
 # set(PLUGIN 0 CACHE BOOL "Build a plugin")

--- a/src/interfaces/src/plugin/api/interfaces/load.c
+++ b/src/interfaces/src/plugin/api/interfaces/load.c
@@ -18,7 +18,7 @@
 #include "plugin/data/interfaces/interface.h"
 #include "plugin/types.h"
 #include "read.h"
-#include "utils/memory.h"
+#include "memory.h"
 #include "utlist.h"
 
 // load APIs

--- a/src/interfaces/src/plugin/data/interfaces/interface.c
+++ b/src/interfaces/src/plugin/data/interfaces/interface.c
@@ -20,7 +20,7 @@
 #include "srpc/ly_tree.h"
 #include "sysrepo.h"
 #include "uthash.h"
-#include "utils/memory.h"
+#include "memory.h"
 #include "utlist.h"
 
 // other data API


### PR DESCRIPTION
without this it will not compile:

```
[ 86%] Linking C executable ietf-interfaces-plugin
/usr/bin/ld: libsrplg-ietf-interfaces-core.a(interface.c.o): in function `interfaces_interface_hash_element_set_name':
sysrepo-plugin-interfaces/src/interfaces/src/plugin/data/interfaces/interface.c:513:(.text+0x3c16): undefined reference to `FREE_SAFE'
/usr/bin/ld: libsrplg-ietf-interfaces-core.a(interface.c.o): in function `interfaces_interface_hash_element_set_description':
sysrepo-plugin-interfaces/src/interfaces/src/plugin/data/interfaces/interface.c:527:(.text+0x3c8f): undefined reference to `FREE_SAFE'
/usr/bin/ld: libsrplg-ietf-interfaces-core.a(interface.c.o): in function `interfaces_interface_hash_element_set_type':
sysrepo-plugin-interfaces/src/interfaces/src/plugin/data/interfaces/interface.c:541:(.text+0x3d0a): undefined reference to `FREE_SAFE'
/usr/bin/ld: libsrplg-ietf-interfaces-core.a(interface.c.o): in function `interfaces_interface_hash_element_set_loopback':
sysrepo-plugin-interfaces/src/interfaces/src/plugin/data/interfaces/interface.c:589:(.text+0x3e9a): undefined reference to `FREE_SAFE'
/usr/bin/ld: libsrplg-ietf-interfaces-core.a(interface.c.o): in function `interfaces_interface_hash_element_set_parent_interface':
sysrepo-plugin-interfaces/src/interfaces/src/plugin/data/interfaces/interface.c:609:(.text+0x3f34): undefined reference to `FREE_SAFE'
collect2: error: ld returned 1 exit status
```