### PR TITLE
devel: fix cmake for interfaces plugin after the change of utils path and include bridge yang files

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PLUGIN_EXECUTABLE_NAME "ietf-interfaces-plugin")
 include_directories(
     ${CMAKE_SOURCE_DIR}/src/interfaces/src
     ${CMAKE_SOURCE_DIR}/deps/uthash
+    ${CMAKE_SOURCE_DIR}/src/utils
 )
 
 # set(PLUGIN 0 CACHE BOOL "Build a plugin")

--- a/src/interfaces/src/plugin/api/interfaces/load.c
+++ b/src/interfaces/src/plugin/api/interfaces/load.c
@@ -18,7 +18,7 @@
 #include "plugin/data/interfaces/interface.h"
 #include "plugin/types.h"
 #include "read.h"
-#include "utils/memory.h"
+#include "memory.h"
 #include "utlist.h"
 
 // load APIs

--- a/src/interfaces/src/plugin/data/interfaces/interface.c
+++ b/src/interfaces/src/plugin/data/interfaces/interface.c
@@ -20,7 +20,7 @@
 #include "srpc/ly_tree.h"
 #include "sysrepo.h"
 #include "uthash.h"
-#include "utils/memory.h"
+#include "memory.h"
 #include "utlist.h"
 
 // other data API

--- a/yang/ieee802-dot1q-bridge.yang
+++ b/yang/ieee802-dot1q-bridge.yang
@@ -1,0 +1,1798 @@
+module ieee802-dot1q-bridge {
+  yang-version "1.1";
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-bridge;
+  prefix dot1q;
+  import ieee802-types {
+    prefix ieee;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+  import iana-if-type {
+    prefix ianaif;
+  }
+  import ieee802-dot1q-types {
+    prefix dot1qtypes;
+  }
+  organization
+    "IEEE 802.1 Working Group";
+  contact
+    "WG-URL: http://ieee802.org/1/
+    WG-EMail: stds-802-1-l@ieee.org
+    
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+           IEEE Standards Association
+           445 Hoes Lane
+           Piscataway, NJ 08854
+           USA
+    
+    E-mail: stds-802-1-chairs@ieee.org";
+  description
+    "This YANG module describes the Bridge configuration model for the
+    following IEEE 802.1Q Bridges:
+       1) Two Port MAC Relays
+       2) Customer VLAN Bridges
+       3) Provider Bridges.
+    
+    Copyright (C) IEEE (2023).
+    
+    This version of this YANG module is part of IEEE Std 802.1Q; see the
+    standard itself for full legal notices.";
+  revision 2023-10-26 {
+    description
+      "Published as part of IEEE Std 802.1Qcw-2023.
+      
+      The following reference statement identifies each referenced IEEE
+      Standard as updated by applicable amendments.";
+    reference
+      "IEEE Std 802.1Q Bridges and Bridged Networks: 
+      IEEE Std 802.1Q-2022, IEEE Std 802.1Qcz-2023, IEEE Std 802.1Qcw-2023. 
+      IEEE Std 802 Overview and Architecture: 
+      IEEE Std 802-2014. 
+      IEEE Std 802.1AC Media Access Control (MAC) Service Definition:
+      IEEE Std 802.1AC-2016, IEEE Std 802.1AC-2016-Cor1-2018.";
+  }
+  revision 2022-10-29 {
+    description
+      "Published as part of IEEE Std 802.1Q-2022.";
+    reference
+      "IEEE Std 802.1Q-2022, Bridges and Bridged Networks.";
+  }
+  revision 2020-11-06 {
+    description
+      "Published as part of IEEE Std 802.1Qcr-2020. Third version.";
+    reference
+      "IEEE Std 802.1Qcr-2020, Bridges and Bridged Networks - Asynchronous
+      Traffic Shaping.";
+  }
+  revision 2020-06-04 {
+    description
+      "Published as part of IEEE Std 802.1Qcx-2020. Second version.";
+    reference
+      "IEEE Std 802.1Qcx-2020, Bridges and Bridged Networks - YANG Data
+      Model for Connectivity Fault Management.";
+  }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018. Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  feature ingress-filtering {
+    description
+      "Each Port may support an Enable Ingress Filtering parameter. A frame
+      received on a Port that is not in the member set (8.8.10) associated
+      with the frames VID shall be discarded if this parameter is set. The
+      default value for this parameter is reset, i.e., Disable Ingress
+      Filtering, for all Ports. Any Port that supports setting this
+      parameter shall also support resetting it. The parameter may be
+      configured by the management operations defined in Clause 12.";
+    reference
+      "8.6.2 of IEEE Std 802.1Q";
+  }
+  feature extended-filtering-services {
+    description
+      "Extended Filtering Services support the filtering behavior required
+      for regions of a network in which potential recipients of multicast
+      frames exist, and where both the potential recipients of frames and
+      the Bridges are able to support dynamic configuration of filtering
+      information for group MAC addresses. In order to integrate this
+      extended filtering behavior with the needs of regions of the network
+      that support only Basic Filtering Services, Bridges that support
+      Extended Filtering Services can be statically and dynamically
+      configured to modify their filtering behavior on a per-group MAC
+      address basis, and also on the basis of the overall filtering service
+      provided by each outbound Port with regard to multicast frames. The
+      latter capability permits configuration of the Port's default
+      forwarding or filtering behavior with regard to group MAC addresses
+      for which no specific static or dynamic filtering information has been
+      configured.";
+    reference
+      "8.8.4, Clause 10 of IEEE Std 802.1Q";
+  }
+  feature port-and-protocol-based-vlan {
+    description
+      "A VLAN-aware Bridge component implementation in conformance to the
+      provisions of this standard for Port-and-Protocol-based VLAN
+      classification (5.4.1) shall 1) Support one or more of the following
+      Protocol Classifications and Protocol Template formats: Ethernet,
+      RFC_1042, SNAP_8021H, SNAP_Other, or LLC_Other (6.12); and may 2)
+      Support configuration of the contents of the Protocol Group Database.";
+    reference
+      "5.4.1.2 of IEEE Std 802.1Q";
+  }
+  feature flow-filtering {
+    description
+      "Flow filtering support enables Bridges to distinguish frames
+      belonging to different client flows and to use this information in the
+      forwarding process. Information related to client flows may be used at
+      the boundary of an SPT Domain to generate a flow hash value. The flow
+      hash, carried in an F-TAG, serves to distinguish frames belonging to
+      different flows and can be used in the forwarding process to
+      distribute frames over equal cost paths. This provides for finer
+      granularity load spreading while maintaining frame order for each
+      client flow.";
+    reference
+      "44.2 of IEEE Std 802.1Q";
+  }
+  feature simple-bridge-port {
+    description
+      "A simple bridge port allows underlying (MAC) layers to share the same
+      Interface as the Bridge Port.";
+  }
+  feature flexible-bridge-port {
+    description
+      "A flexible Bridge Port provides an interface that is distinct from 
+      the interface provided by the underlying (MAC) layer.";
+  }
+  identity type-of-bridge {
+    description
+      "Represents the configured Bridge type.";
+  }
+  identity customer-vlan-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Customer VLAN Bridge.";
+  }
+  identity provider-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Provider Bridge (PB).";
+  }
+  identity provider-edge-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Provider Edge Bridge (PEB).";
+  }
+  identity two-port-mac-relay-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Two Port MAC Relay (TPMR).";
+  }
+  identity type-of-component {
+    description
+      "Represents the type of Component.";
+  }
+  identity c-vlan-component {
+    base type-of-component;
+    description
+      "Base identity for a C-VLAN component.";
+  }
+  identity s-vlan-component {
+    base type-of-component;
+    description
+      "Base identity for a S-VLAN component.";
+  }
+  identity d-bridge-component {
+    base type-of-component;
+    description
+      "Base identity for a VLAN unaware component.";
+  }
+  identity edge-relay-component {
+    base type-of-component;
+    description
+      "Base identity for an EVB station ER component.";
+  }
+  identity type-of-port {
+    description
+      "Represents the type of Bridge port.";
+  }
+  identity c-vlan-bridge-port {
+    base type-of-port;
+    description
+      "Indicates the port can be a C-TAG aware port of an enterprise VLAN
+      aware Bridge.";
+  }
+  identity provider-network-port {
+    base type-of-port;
+    description
+      "Indicates the port can be an S-TAG aware port of a Provider Bridge or
+      Backbone Edge Bridge used for connections within a PBN (Provider
+      Bridged Network) or PBBN (Provider Backbone Bridged Network).";
+  }
+  identity customer-network-port {
+    base type-of-port;
+    description
+      "Indicates the port can be an S-TAG aware port of a Provider Bridge or
+      Backbone Edge Bridge used for connections to the exterior of a PBN
+      (Provider Bridged Network) or PBBN (Provider Backbone Bridged
+      Network).";
+  }
+  identity customer-edge-port {
+    base type-of-port;
+    description
+      "Indicates the port can be a C-TAG aware port of a Provider Bridge
+      used for connections to the exterior of a PBN (Provider Bridged
+      Network) or PBBN (Provider Backbone Bridged Network).";
+  }
+  identity d-bridge-port {
+    base type-of-port;
+    description
+      "Indicates the port can be a VLAN-unaware member of an 802.1Q Bridge.";
+  }
+  identity remote-customer-access-port {
+    base type-of-port;
+    description
+      "Indicates the port can be an S-TAG aware port of a Provider Bridge
+      capable of providing Remote Customer Service Interfaces.";
+  }
+  identity bridge-interface {
+    description
+      "Generic interface property that represents any interface that can be
+      associated with an IEEE 802.1Q compliant Bridge component. Any new
+      Interface types would derive from this identity to automatically pick
+      up Bridge related configuration or operational data.";
+  }
+  container bridges {
+    description
+      "Contains the Bridge(s) configuration information.";
+    list bridge {
+      key "name";
+      unique "address";
+      description
+        "Provides configuration data in support of the Bridge Configuration
+        resources. There is a single bridge data node per Bridge.";
+      leaf name {
+        type dot1qtypes:name-type;
+        description
+          "A text string associated with the Bridge, of locally determined
+          significance.";
+        reference
+          "12.4 of IEEE Std 802.1Q";
+      }
+      leaf address {
+        type ieee:mac-address;
+        mandatory true;
+        description
+          "The MAC address for the Bridge from which the Bridge Identifiers
+          used by the STP, RSTP, and MSTP are derived.";
+        reference
+          "12.4 of IEEE Std 802.1Q";
+      }
+      leaf bridge-type {
+        type identityref {
+          base type-of-bridge;
+        }
+        mandatory true;
+        description
+          "The type of Bridge.";
+      }
+      leaf ports {
+        type uint16 {
+          range "1..4095";
+        }
+        config false;
+        description
+          "The number of Bridge Ports (MAC Entities)";
+        reference
+          "12.4 of IEEE Std 802.1Q";
+      }
+      leaf up-time {
+        type yang:zero-based-counter32;
+        units "seconds";
+        config false;
+        description
+          "The count in seconds of the time elapsed since the Bridge was
+          last reset or initialized.";
+        reference
+          "12.4 of IEEE Std 802.1Q";
+      }
+      leaf components {
+        type uint32;
+        config false;
+        description
+          "The number of components associated with the Bridge.";
+      }
+      list component {
+        key "name";
+        description
+          "The set of components associated with a given Bridge. For
+          example, - A TPMR is associated with a single VLAN unaware
+          component. - A Customer VLAN Bridge is associated with a single
+          VLAN aware component. - A Provider Bridge is associated with a
+          single S-VLAN component and zero or more C-VLAN components.";
+        reference
+          "12.4.1.5 of IEEE Std 802.1Q";
+        leaf name {
+          type string;
+          description
+            "The name of the Component.";
+        }
+        leaf id {
+          type uint32;
+          description
+            "Unique identifier for a particular Bridge component within the
+            system.";
+          reference
+            "Item l) in 12.3 of IEEE Std 802.1Q";
+        }
+        leaf type {
+          type identityref {
+            base type-of-component;
+          }
+          mandatory true;
+          description
+            "The type of component used to classify a particular Bridge
+            component within a Bridge system comprising multiple components.";
+          reference
+            "Item m) in 12.3 of IEEE Std 802.1Q";
+        }
+        leaf address {
+          type ieee:mac-address;
+          description
+            "Unique EUI-48 Universally Administered MAC address assigned to
+            a Bridge component.";
+          reference
+            "8.13.8 of IEEE Std 802.1Q";
+        }
+        leaf traffic-class-enabled {
+          type boolean;
+          default "true";
+          description
+            "Indication of Traffic Classes enablement associated with the
+            Bridge Component. A value of True indicates that Traffic Classes
+            are enabled on this Bridge Component. A value of False indicates
+            that the Bridge Component operates with a single priority level
+            for all traffic.";
+          reference
+            "Item b) in 12.4.1.5.2 of IEEE Std 802.1Q";
+        }
+        leaf ports {
+          type uint16 {
+            range "1..4095";
+          }
+          config false;
+          description
+            "The number of Bridge Ports associated with the Bridge
+            Component.";
+          reference
+            "Item c) in 12.4.1.1.3 of IEEE Std 802.1Q";
+        }
+        leaf-list bridge-port {
+          type if:interface-ref;
+          config false;
+          description
+            "List of bridge-port references.";
+        }
+        container capabilities {
+          config false;
+          description
+            "Array of Boolean values of the feature capabilities associated
+            with a given Bridge Component.";
+          reference
+            "Item b) in 12.10.1.1.3, 12.4.1.5.2 of IEEE Std 802.1Q";
+          leaf extended-filtering {
+            type boolean;
+            default "false";
+            description
+              "Can perform filtering on individual multicast addresses
+              controlled by MMRP.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf traffic-classes {
+            type boolean;
+            default "false";
+            description
+              "Can map priority to multiple traffic classes.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf static-entry-individual-port {
+            type boolean;
+            default "false";
+            description
+              "Static entries per port.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf ivl-capable {
+            type boolean;
+            default "true";
+            description
+              "Independent VLAN Learning (IVL).";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf svl-capable {
+            type boolean;
+            default "false";
+            description
+              "Shared VLAN Learning (SVL).";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf hybrid-capable {
+            type boolean;
+            default "false";
+            description
+              "Both IVL and SVL simultaneously.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf configurable-pvid-tagging {
+            type boolean;
+            default "false";
+            description
+              "Whether the implementation supports the ability to override
+              the default PVID setting and its egress status (VLAN-tagged or
+              Untagged) on each port.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+          leaf local-vlan-capable {
+            type boolean;
+            default "false";
+            description
+              "Can support multiple local Bridges, outside the scope of
+              802.1Q defined VLANs.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q";
+          }
+        }
+        container filtering-database {
+          when
+            "not(derived-from-or-self(../../bridge-type, "+
+            "'two-port-mac-relay-bridge'))" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "Contains filtering information used by the Forwarding Process
+            in deciding through which Ports of the Bridge frames should be
+            forwarded.";
+          reference
+            "12.7 of IEEE Std 802.1Q";
+          leaf aging-time {
+            type uint32 {
+              range "10..1000000";
+            }
+            units "seconds";
+            default "300";
+            description
+              "The timeout period in seconds for aging out
+              dynamically-learned forwarding information.";
+            reference
+              "12.7, 8.8.3 of IEEE Std 802.1Q";
+          }
+          leaf size {
+            type yang:gauge32;
+            config false;
+            description
+              "The maximum number of entries that can be held in the FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q";
+          }
+          leaf static-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static Filtering entries currently in the FDB.";
+            reference
+              "12.7, 8.8.1 of IEEE Std 802.1Q";
+          }
+          leaf dynamic-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Dynamic Filtering entries currently in the FDB.";
+            reference
+              "12.7, 8.8.3 of IEEE Std 802.1Q";
+          }
+          leaf static-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static VLAN Registration entries currently in
+              the FDB.";
+            reference
+              "12.7, 8.8.2 of IEEE Std 802.1Q";
+          }
+          leaf dynamic-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Dynamic VLAN Registration entries currently in
+              the FDB.";
+            reference
+              "12.7, 8.8.5 of IEEE Std 802.1Q";
+          }
+          leaf mac-address-registration-entries {
+            if-feature "extended-filtering-services";
+            type yang:gauge32;
+            config false;
+            description
+              "The number of MAC Address Registration entries currently in
+              the FDB.";
+            reference
+              "12.7, 8.8.4 of IEEE Std 802.1Q";
+          }
+          list filtering-entry {
+            key "database-id vids address";
+            description
+              "Information for the entries associated with the Permanent
+              Database.";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf address {
+              type ieee:mac-address;
+              description
+                "A MAC address (unicast, multicast, broadcast) for which the
+                device has forwarding and/or filtering information.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The set of VLAN identifiers to which this entry applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf entry-type {
+              type enumeration {
+                enum static {
+                  description
+                    "Static entry type";
+                }
+                enum dynamic {
+                  description
+                    "Dynamic/learnt entry type";
+                }
+              }
+              description
+                "The type of filtering entry. Whether static or dynamic.
+                Static entries can be created, deleted, and retrieved.
+                However, dynamic entries can only be deleted or retrieved by
+                the management entity. Consequently, a Bridge is not
+                required to accept a command that can alter the dynamic
+                entries except delete a dynamic entry.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            uses dot1qtypes:port-map-grouping;
+            leaf status {
+              type enumeration {
+                enum other {
+                  description
+                    "None of the following. This may include the case where
+                    some other object is being used to determine if and how
+                    frames addressed to the value of the corresponding
+                    instance of 'address' are being forwarded.";
+                }
+                enum invalid {
+                  description
+                    "This entry is no longer valid (e.g., it was learned but
+                    has since aged out), but has not yet been flushed from
+                    the table.";
+                }
+                enum learned {
+                  description
+                    "The value of the corresponding instance of the port
+                    node was learned and is being used.";
+                }
+                enum self {
+                  description
+                    "The value of the corresponding instance of the address
+                    node representing one of the devices address.";
+                }
+                enum mgmt {
+                  description
+                    "The value of the corresponding instance of address node
+                    that is also the value of an existing instance.";
+                }
+              }
+              config false;
+              description
+                "The status of this entry.";
+            }
+          }
+          list vlan-registration-entry {
+            key "database-id vids";
+            description
+              "The VLAN Registration Entries models the operations that can
+              be performed on a single VLAN Registration Entry in the FDB.
+              The set of VLAN Registration Entries within the FDB changes
+              under management control and also as a result of MVRP
+              exchanges";
+            reference
+              "12.7.5 of IEEE Std 802.1Q";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The set of VLAN identifiers to which this entry applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf entry-type {
+              type enumeration {
+                enum static {
+                  description
+                    "Static entry type";
+                }
+                enum dynamic {
+                  description
+                    "Dynamic/learnt entry type";
+                }
+              }
+              description
+                "The type of filtering entry. Whether static or dynamic.
+                Static entries can be created, deleted, and retrieved.
+                However, dynamic entries can only be deleted or retrieved by
+                the management entity. Consequently, a Bridge is not
+                required to accept a command that can alter the dynamic
+                entries except delete a dynamic entry.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            uses dot1qtypes:port-map-grouping;
+          }
+        }
+        container permanent-database {
+          description
+            "The Permanent Database container models the operations that can
+            be performed on, or affect, the Permanent Database. There is a
+            single Permanent Database per FDB.";
+          leaf size {
+            type yang:gauge32;
+            config false;
+            description
+              "The maximum number of entries that can be held in the FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q";
+          }
+          leaf static-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static Filtering entries currently in the FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q";
+          }
+          leaf static-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static VLAN Registration entries currently in
+              the FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q";
+          }
+          list filtering-entry {
+            key "database-id vids address";
+            description
+              "Information for the entries associated with the Permanent
+              Database.";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf address {
+              type ieee:mac-address;
+              description
+                "A MAC address (unicast, multicast, broadcast) for which the
+                device has forwarding and/or filtering information.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The set of VLAN identifiers to which this entry applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf status {
+              type enumeration {
+                enum other {
+                  description
+                    "None of the following. This may include the case where
+                    some other object is being used to determine if and how
+                    frames addressed to the value of the corresponding
+                    instance of 'address' are being forwarded.";
+                }
+                enum invalid {
+                  description
+                    "This entry is no longer valid (e.g., it was learned but
+                    has since aged out), but has not yet been flushed from
+                    the table.";
+                }
+                enum learned {
+                  description
+                    "The value of the corresponding instance of the port
+                    node was learned and is being used.";
+                }
+                enum self {
+                  description
+                    "The value of the corresponding instance of the address
+                    node representing one of the devices address.";
+                }
+                enum mgmt {
+                  description
+                    "The value of the corresponding instance of address node
+                    that is also the value of an existing instance.";
+                }
+              }
+              config false;
+              description
+                "The status of this entry.";
+            }
+            uses dot1qtypes:port-map-grouping;
+          }
+        }
+        container bridge-vlan {
+          when
+            "not(derived-from-or-self(../../bridge-type, "+
+            "'two-port-mac-relay-bridge'))" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "The Bridge VLAN container models configuration information that
+            modifies, or inquires about, the overall configuration of the
+            Bridge's VLAN resources. There is a single Bridge VLAN
+            Configuration managed object per Bridge.";
+          reference
+            "12.10 of IEEE Std 802.1Q";
+          leaf version {
+            type uint16;
+            config false;
+            description
+              "The version number supported.";
+            reference
+              "Item a) of 12.10.1.1.3 of IEEE Std 802.1Q";
+          }
+          leaf max-vids {
+            type uint16;
+            config false;
+            description
+              "The maximum number of VIDs supported.";
+            reference
+              "Item b)1) of 12.10.1.1.3 of IEEE Std 802.1Q";
+          }
+          leaf override-default-pvid {
+            type boolean;
+            default "false";
+            config false;
+            description
+              "Indicates if the default PVID can be overridden, and its
+              egress status (VLAN-tagged or untagged) on each port.";
+            reference
+              "Item b)2) of 12.10.1.1.3 of IEEE Std 802.1Q";
+          }
+          leaf protocol-template {
+            if-feature "port-and-protocol-based-vlan";
+            type dot1qtypes:protocol-frame-format-type;
+            config false;
+            description
+              "The data-link encapsulation format or the detagged_frame_type
+              in a Protocol Template";
+            reference
+              "12.10.1.7 of IEEE Std 802.1Q";
+          }
+          leaf max-msti {
+            type uint16;
+            config false;
+            description
+              "The maximum number of MSTIs supported within an MST region
+              (i.e., the number of spanning tree instances that can be
+              supported in addition to the CIST), for MST Bridges. For SST
+              Bridges, this parameter may be either omitted or reported as
+              0.";
+            reference
+              "Item b)4) of 12.10.1.1.3 of IEEE Std 802.1Q";
+          }
+          list vlan {
+            key "vid";
+            description
+              "List of VLAN related configuration nodes associated with the
+              Bridge.";
+            reference
+              "12.10.2 of IEEE Std 802.1Q";
+            leaf vid {
+              type dot1qtypes:vlan-index-type;
+              description
+                "The VLAN identifier to which this entry applies.";
+              reference
+                "12.10.2 of IEEE Std 802.1Q";
+            }
+            leaf name {
+              type dot1qtypes:name-type;
+              description
+                "A text string of up to 32 characters of locally determined
+                significance.";
+              reference
+                "12.10.2 of IEEE Std 802.1Q";
+            }
+            leaf-list untagged-ports {
+              type if:interface-ref;
+              config false;
+              description
+                "The set of ports in the untagged set for this VID.";
+              reference
+                "12.10.2.1.3, 8.8.2 of IEEE Std 802.1Q";
+            }
+            leaf-list egress-ports {
+              type if:interface-ref;
+              config false;
+              description
+                "The set of egress ports in the member set for this VID.";
+              reference
+                "12.10.2.1.3, 8.8.10 of IEEE Std 802.1Q";
+            }
+          }
+          list protocol-group-database {
+            if-feature "port-and-protocol-based-vlan";
+            key "db-index";
+            description
+              "List of the protocol group database entries.";
+            reference
+              "12.10.1.7, 6.12.3 of IEEE Std 802.1Q";
+            leaf db-index {
+              type uint16;
+              description
+                "The protocol group database index.";
+            }
+            leaf frame-format-type {
+              type dot1qtypes:protocol-frame-format-type;
+              description
+                "The data-link encapsulation format or the
+                detagged_frame_type in a Protocol Template";
+              reference
+                "12.10.1.7 of IEEE Std 802.1Q";
+            }
+            choice frame-format {
+              description
+                "The identification of the protocol above the data-link
+                layer in a Protocol Template. Depending on the frame type,
+                the octet string will have one of the following values:
+                - For Ethernet, rfc1042, and snap8021H, this is the 16-bit
+                (2-octet) EtherType field.
+                - For snapOther, this is the 40-bit (5-octet) PID. 
+                - For llcOther, this is the 2-octet IEEE 802.2 Link Service
+                Access Point (LSAP) pair: first octet for Destination Service
+                Access Point (DSAP) and second octet for Source Service Access
+                Point (SSAP).";
+              reference
+                "12.10.1.7 of IEEE Std 802.1Q";
+              case ethernet-rfc1042-snap8021H {
+                when
+                  "frame-format-type = 'Ethernet' or frame-format-type = "+
+                  "'rfc1042' or frame-format-type = 'snap8021H'" {
+                  description
+                    "Applies to Ethernet, RFC 1042, SNAP 8021H frame
+                    formats.";
+                }
+                description
+                  "Identifier used if Ethenet, RFC1042, or SNAP 8021H.";
+                leaf ethertype {
+                  type dot1qtypes:ethertype-type;
+                  description
+                    "Format containing the 16-bit IEEE 802 EtherType field.";
+                  reference
+                    "9.2 of IEEE Std 802";
+                }
+              }
+              case snap-other {
+                when
+                  "frame-format-type = 'snapOther'" {
+                  description
+                    "Applies to Snap Other frame formats.";
+                }
+                description
+                  "Identifier used if SNAP other.";
+                leaf protocol-id {
+                  type string {
+                    pattern "[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){4}";
+                  }
+                  description
+                    "Format containing the 40-bit protocol identifier (PID).
+                    The canonical representation uses uppercase characters.";
+                  reference
+                    "12.10.1.7.1 of IEEE Std 802.1Q";
+                }
+              }
+              case llc-other {
+                when
+                  "frame-format-type = 'llcOther'" {
+                  description
+                    "Applies to LLC Other frame formats";
+                }
+                description
+                  "Identifier used if LLC other.";
+                container dsap-ssap-pairs {
+                  description
+                    "A pair of ISO/IEC 8802-2 DSAP and SSAP address field
+                    values, for matching frame formats of LLC_Other.";
+                  leaf llc-address {
+                    type string {
+                      pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
+                    }
+                    description
+                      "A pair of ISO/IEC 8802-2 DSAP and SSAP address field
+                      values, for matching frame formats of LLC_Other. The
+                      canonical representation uses uppercase characters.";
+                    reference
+                      "12.10.1.7.1 of IEEE Std 802.1Q";
+                  }
+                }
+              }
+            }
+            leaf group-id {
+              type uint32;
+              description
+                "Designates a group of protocols in the Protocol Group
+                Database.";
+              reference
+                "6.12.2 of IEEE Std 802.1Q";
+            }
+          }
+          list vid-to-fid-allocation {
+            key "vids";
+            description
+              "This list allows inquiries about VID to FID allocations.";
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "Range of VLAN identifiers.";
+              reference
+                "12.10.3 of IEEE Std 802.1Q";
+            }
+            leaf fid {
+              type uint32;
+              config false;
+              description
+                "The Filtering Database used by a set of VIDs.";
+              reference
+                "12.10.3 of IEEE Std 802.1Q";
+            }
+            leaf allocation-type {
+              type enumeration {
+                enum undefined {
+                  description
+                    "No allocation defined.";
+                }
+                enum fixed {
+                  description
+                    "A fixed allocation to FID is defined.";
+                }
+                enum dynamic {
+                  description
+                    "A dynamic allocation to FID is defined.";
+                }
+              }
+              config false;
+              description
+                "The type of allocation used";
+              reference
+                "12.10.3 of IEEE Std 802.1Q";
+            }
+          }
+          list fid-to-vid-allocation {
+            key "fid";
+            description
+              "The FID to VID allocations managed object models operations
+              that inquire about FID to VID allocations.";
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database used by a set of VIDs.";
+              reference
+                "12.10.3 of IEEE Std 802.1Q";
+            }
+            leaf allocation-type {
+              type enumeration {
+                enum undefined {
+                  description
+                    "No allocation defined.";
+                }
+                enum fixed {
+                  description
+                    "A fixed allocation to FID is defined.";
+                }
+                enum dynamic {
+                  description
+                    "A dynamic allocation to FID is defined.";
+                }
+              }
+              config false;
+              description
+                "The type of allocation used";
+              reference
+                "12.10.3 of IEEE Std 802.1Q";
+            }
+            leaf-list vid {
+              type dot1qtypes:vlan-index-type;
+              config false;
+              description
+                "The VLAN identifier to which this entry applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+          }
+          list vid-to-fid {
+            key "vid";
+            description
+              "Fixed allocation of a VID to an FID. The underlying system
+              will ensure that subsequent commands that make changes to the
+              VID to FID mapping can override previous associations.";
+            reference
+              "12.10.3.4, 12.10.3.5 of IEEE Std 802.1Q";
+            leaf vid {
+              type dot1qtypes:vlan-index-type;
+              description
+                "A list of VIDs associated with a given database identifier 
+                (i.e., FID).";
+              reference
+                "12.7.7 of IEEE Std 802.1Q";
+            }
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database used by this VLAN";
+              reference
+                "12.10.3 of IEEE Std 802.1Q";
+            }
+          }
+        }
+        container bridge-mst {
+          when
+            "not(derived-from-or-self(../../bridge-type, "+
+            "'two-port-mac-relay-bridge'))" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "The Bridge MST container models configuration information that
+            modifies, or inquires about, the overall configuration of the
+            Bridges MST resources.";
+          reference
+            "12.12 of IEEE Std 802.1Q";
+          leaf-list mstid {
+            type dot1qtypes:mstid-type;
+            description
+              "The list of MSTID values that are currently supported by the
+              Bridge";
+          }
+          list fid-to-mstid {
+            key "fid";
+            description
+              "The FID to MSTID allocation table.";
+            reference
+              "12.12.2 of IEEE Std 802.1Q";
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database identifier.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q";
+            }
+            leaf mstid {
+              type dot1qtypes:mstid-type;
+              description
+                "The MSTID to which the FID is to be allocated.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q";
+            }
+          }
+          list fid-to-mstid-allocation {
+            key "fids";
+            description
+              "The FID to MSTID allocation table";
+            leaf fids {
+              type dot1qtypes:vid-range-type;
+              description
+                "Range of FIDs.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q";
+            }
+            leaf mstid {
+              type dot1qtypes:mstid-type;
+              description
+                "The MSTID to which the FID is allocated.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q";
+            }
+          }
+        }
+      }
+    }
+  }
+  augment "/if:interfaces/if:interface" {
+    when
+      "derived-from-or-self(if:type,'ianaif:bridge') or "+
+      "derived-from-or-self(if:type,'ianaif:ethernetCsmacd') or "+
+      "derived-from-or-self(if:type,'ianaif:ieee8023adLag') or "+
+      "derived-from-or-self(if:type,'ianaif:ilan')" {
+      description
+        "Applies when a Bridge interface.";
+    }
+    description
+      "Augment the interface model with the Bridge Port";
+    container bridge-port {
+      description
+        "Bridge Port is an extension of the IETF Interfaces model (RFC7223).";
+      leaf bridge-name {
+        type leafref {
+          path '/dot1q:bridges/dot1q:bridge/dot1q:name';
+        }
+        
+        description
+          "Used to reference configured Bridge node.";
+      }
+      leaf component-name {
+        type leafref {
+          path
+            '/dot1q:bridges'+
+            '/dot1q:bridge[dot1q:name=current()'+
+            '/..'+
+            '/bridge-name]'+
+            '/dot1q:component'+
+            '/dot1q:name';
+        }
+        
+        description
+          "Used to reference configured Component node.";
+      }
+      leaf port-type {
+        type identityref {
+          base type-of-port;
+        }
+        description
+          "The port type. Indicates the capabilities of this port.";
+        reference
+          "12.4.2.1 of IEEE Std 802.1Q";
+      }
+      leaf pvid {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type dot1qtypes:vlan-index-type;
+        default "1";
+        description
+          "The primary (default) VID assigned to a specific Bridge Port.";
+        reference
+          "12.10.1, 5.4, item m) of IEEE Std 802.1Q";
+      }
+      leaf default-priority {
+        type dot1qtypes:priority-type;
+        default "0";
+        description
+          "The default priority assigned to a specific Bridge Port.";
+        reference
+          "12.6.2 of IEEE Std 802.1Q";
+      }
+      container priority-regeneration {
+        description
+          "The Priority Regeneration Table parameters associated with a
+          specific Bridge Port. A list of Regenerated User Priorities for
+          each received priority on each port of a Bridge. The regenerated
+          priority value may be used to index the Traffic Class Table for
+          each input port. This only has effect on media that support native
+          priority. The default values for Regenerated User Priorities are
+          the same as the User Priorities";
+        reference
+          "12.6.2, 6.9.4 of IEEE Std 802.1Q";
+        uses dot1qtypes:priority-regeneration-table-grouping;
+      }
+      leaf pcp-selection {
+        type dot1qtypes:pcp-selection-type;
+        default "8P0D";
+        description
+          "The Priority Code Point selection assigned to a specific Bridge
+          Port. This object identifies the rows in the PCP encoding and
+          decoding tables that are used to remark frames on this port if
+          this remarking is enabled";
+        reference
+          "12.6.2, 6.9.3 of IEEE Std 802.1Q";
+      }
+      container pcp-decoding-table {
+        description
+          "The Priority Code Point Decoding Table parameters associated with
+          a specific Bridge Port.";
+        uses dot1qtypes:pcp-decoding-table-grouping;
+      }
+      container pcp-encoding-table {
+        description
+          "The Priority Code Point Encoding Table parameters associated with
+          a specific Bridge Port.";
+        uses dot1qtypes:pcp-encoding-table-grouping;
+      }
+      leaf use-dei {
+        type boolean;
+        default "false";
+        description
+          "The Drop Eligible Indicator. If it is set to True, then the
+          drop_eligible parameter is encoded in the DEI of transmitted
+          frames, and the drop_eligible parameter shall be true(1) for a
+          received frame if the DEI is set in the VLAN tag or the Priority
+          Code Point Decoding Table indicates drop_eligible True for the
+          received PCP value. If this parameter is False, the DEI shall be
+          transmitted as zero and ignored on receipt.";
+        reference
+          "12.6.2, 6.9.3 of IEEE Std 802.1Q";
+      }
+      leaf drop-encoding {
+        type boolean;
+        default "false";
+        description
+          "The Drop Encoding parameter. If a Bridge supports encoding or
+          decoding of drop_eligible from the PCP field of a VLAN tag (6.9.3)
+          on any of its Ports, then it shall implement a Boolean parameter
+          Require Drop Encoding on each of its Ports with default value
+          False. If Require Drop Encoding is True and the Bridge Port cannot
+          encode particular priorities with drop_eligible, then frames
+          queued with those priorities and drop_eligible True shall be
+          discarded and not transmitted.";
+        reference
+          "12.6.2, 6.9.3 of IEEE Std 802.1Q";
+      }
+      leaf service-access-priority-selection {
+        type boolean;
+        default "false";
+        description
+          "The Service Access Priority selection. Indication of whether the
+          Service Access Priority Selection function is supported on the
+          Customer Bridge Port to request priority handling of the frame
+          from a Port-based service interface.";
+        reference
+          "12.6.2, 6.13 of IEEE Std 802.1Q";
+      }
+      container service-access-priority {
+        description
+          "The Service Access Priority table parameters. A table that
+          contains information about the Service Access Priority Selection
+          function for a Provider Bridge. The use of this table enables a
+          mechanism for a Customer Bridge attached to a Provider Bridged
+          Network to request priority handling of frames.";
+        reference
+          "12.6.2, 6.13.1 of IEEE Std 802.1Q";
+        uses dot1qtypes:service-access-priority-table-grouping;
+      }
+      container traffic-class {
+        description
+          "The Traffic Class table parameters. A table mapping evaluated
+          priority to Traffic Class, for forwarding by the Bridge";
+        reference
+          "12.6.3, 8.6.6 of IEEE Std 802.1Q";
+        uses dot1qtypes:traffic-class-table-grouping;
+      }
+      container transmission-selection-algorithm-table {
+        description
+          "The Transmission Selection Algorithm Table for a given Port
+          assigns, for each traffic class that the Port supports, the
+          transmission selection algorithm that is to be used to select
+          frames for transmission from the corresponding queue. Transmission
+          Selection Algorithm Tables may be managed, and allow the
+          identification of vendor-specific transmission selection
+          algorithms. The transmission selection algorithms are identified
+          in the Transmission Selection Algorithm Table by means of integer
+          identifiers.";
+        reference
+          "12.20.2, 8.6.8 of IEEE Std 802.1Q";
+        uses dot1qtypes:transmission-selection-table-grouping;
+      }
+      leaf acceptable-frame {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type enumeration {
+          enum admit-only-VLAN-tagged-frames {
+            description
+              "Admit only VLAN-tagged frames.";
+          }
+          enum admit-only-untagged-and-priority-tagged {
+            description
+              "Admit only untagged and priority-tagged frames.";
+          }
+          enum admit-all-frames {
+            description
+              "Admit all frames.";
+          }
+        }
+        default "admit-all-frames";
+        description
+          "To configure the Acceptable Frame Types parameter associated with
+          one or more Ports";
+        reference
+          "12.10.1.3, 6.9 of IEEE Std 802.1Q";
+      }
+      leaf enable-ingress-filtering {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable the Ingress Filtering feature associated with one or
+          more Ports.";
+        reference
+          "12.10.1.4, 8.6.2 of IEEE Std 802.1Q";
+      }
+      leaf enable-restricted-vlan-registration {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable the Restricted VLAN Registration associated with one or
+          more Ports.";
+        reference
+          "11.2.3.2.3, 12.10.1.6 of IEEE Std 802.1Q";
+      }
+      leaf enable-vid-translation-table {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable VID Translation table associated with a Bridge Port.
+          This is not applicable to Bridge Ports that do no support a VID
+          Translation Table.";
+        reference
+          "12.10.1.8, 6.9 of IEEE Std 802.1Q";
+      }
+      leaf enable-egress-vid-translation-table {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable Egress VID Translation table associated with a Bridge
+          Port. This is not applicable to Ports that do not support an
+          Egress VID Translation table.";
+        reference
+          "12.10.1.8, 6.9 of IEEE Std 802.1Q";
+      }
+      list protocol-group-vid-set {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
+        key "group-id";
+        description
+          "The list of VID values associated with the Protocol Group
+          Identifier for this port.";
+        reference
+          "12.10.1.1.3 of IEEE Std 802.1Q";
+        leaf group-id {
+          type uint32;
+          description
+            "The protocol group identifier";
+          reference
+            "12.10.1.7 of IEEE Std 802.1Q";
+        }
+        leaf-list vid {
+          type dot1qtypes:vlanid;
+          description
+            "The VLAN identifier to which this entry applies.";
+          reference
+            "12.10.2 of IEEE Std 802.1Q";
+        }
+      }
+      leaf admin-point-to-point {
+        type enumeration {
+          enum force-true {
+            value 1;
+            description
+              "Indicates that this port should always be treated as if it is
+              connected to a point-to-point link.";
+          }
+          enum force-false {
+            value 2;
+            description
+              "Indicates that this port should be treated as having a shared
+              media connection.";
+          }
+          enum auto {
+            value 3;
+            description
+              "Indicates that this port is considered to have a
+              point-to-point link if it is an Aggregator and all of its
+              members are aggregatable, or if the MAC entity is configured
+              for full duplex operation, either through auto-negotiation or
+              by management means.";
+          }
+        }
+        description
+          "For a port running spanning tree, this object represents the
+          administrative point-to-point status of the LAN segment attached
+          to this port, using the enumeration values of IEEE Std 802.1AC. A
+          value of forceTrue(1) indicates that this port should always be
+          treated as if it is connected to a point-to-point link. A value of
+          forceFalse(2) indicates that this port should be treated as having
+          a shared media connection. A value of auto(3) indicates that this
+          port is considered to have a point-to-point link if it is an
+          Aggregator and all of its members are aggregatable, or if the MAC
+          entity is configured for full duplex operation, either through
+          auto-negotiation or by management means. Manipulating this object
+          changes the underlying adminPointToPointMAC.";
+        reference
+          "12.4.2, 6.8.3 of IEEE Std 802.1Q; 11.3 of IEEE Std 802.1AC";
+      }
+      leaf protocol-based-vlan-classification {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
+        type boolean;
+        config false;
+        description
+          "A boolean indication indicating if Port-and-Protocol-based VLAN
+          classification is supported on a given Port.";
+        reference
+          "5.4.1.2 of IEEE Std 802.1Q";
+      }
+      leaf max-vid-set-entries {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
+        type uint16;
+        config false;
+        description
+          "The maximum number of entries supported in the VID set on a given
+          Port.";
+        reference
+          "12.10.1.1.3 of IEEE Std 802.1Q";
+      }
+      leaf port-number {
+        type dot1qtypes:port-number-type;
+        config false;
+        description
+          "An integer that uniquely identifies a Bridge Port.";
+        reference
+          "Item i) in 12.3, 17.3.2.2 of IEEE Std 802.1Q";
+      }
+      leaf address {
+        type ieee:mac-address;
+        config false;
+        description
+          "The specific MAC address of the individual MAC Entity associated
+          with the Port.";
+        reference
+          "12.4.2, Item a) in 12.4.1.1.3 of IEEE Std 802.1Q";
+      }
+      leaf capabilities {
+        type bits {
+          bit tagging {
+            position 0;
+            description
+              "Supports 802.1Q VLAN tagging of frames and MVRP.";
+          }
+          bit configurable-acceptable-frame-type {
+            position 1;
+            description
+              "Allows modified values of acceptable frame types";
+          }
+          bit ingress-filtering {
+            position 2;
+            description
+              "Supports the discarding of any frame received on a Port whose
+              VLAN classification does not include that Port in its member
+              set.";
+          }
+        }
+        config false;
+        description
+          "The feature capabilities associated with port. Indicates the
+          parts of IEEE 802.1Q that are optional on a per-port basis, that
+          are implemented by this device, and that are manageable.";
+        reference
+          "Item c) in 12.10.1.1.3, 12.4.2 of IEEE Std 802.1Q";
+      }
+      leaf type-capabilties {
+        type bits {
+          bit customer-vlan-port {
+            position 0;
+            description
+              "Indicates the port can be a C-TAG aware port of an enterprise
+              VLAN aware Bridge";
+          }
+          bit provider-network-port {
+            position 1;
+            description
+              "Indicates the port can be an S-TAG aware port of a Provider
+              Bridge or Backbone Edge Bridge used for connections within a
+              PBN or PBBN.";
+          }
+          bit customer-network-port {
+            position 2;
+            description
+              "Indicates the port can be an S-TAG aware port of a Provider
+              Bridge or Backbone Edge Bridge used for connections to the
+              exterior of a PBN or PBBN.";
+          }
+          bit customer-edge-port {
+            position 3;
+            description
+              "Indicates the port can be a C-TAG aware port of a Provider
+              Bridge used for connections to the exterior of a PBN or PBBN.";
+          }
+          bit customer-backbone-port {
+            position 4;
+            description
+              "Indicates the port can be a I-TAG aware port of a Backbone
+              Edge Bridge's B-component.";
+          }
+          bit virtual-instance-port {
+            position 5;
+            description
+              "Indicates the port can be a virtual S-TAG aware port within a
+              Backbone Edge Bridge's I-component which is responsible for
+              handling S-tagged traffic for a specific backbone service
+              instance.";
+          }
+          bit d-bridge-port {
+            position 6;
+            description
+              "Indicates the port can be a VLAN-unaware member of an 802.1Q
+              Bridge.";
+          }
+          bit remote-customer-access-port {
+            position 7;
+            description
+              "Indicates the port can be an S-TAG aware port of a Provider
+              Bridge capable of providing Remote Customer Service
+              Interfaces.";
+          }
+          bit station-facing-bridge-port {
+            position 8;
+            description
+              "Indicates the station-facing Bridge Port in a EVB Bridge.";
+          }
+          bit uplink-access-port {
+            position 9;
+            description
+              "Indicates the uplink access port in an EVB Bridge or EVB
+              station.";
+          }
+          bit uplink-relay-port {
+            position 10;
+            description
+              "Indicates the uplink relay port in an EVB station.";
+          }
+        }
+        config false;
+        description
+          "The type of feature capabilities supported with port. Indicates
+          the capabilities of this port.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q";
+      }
+      leaf external {
+        type boolean;
+        config false;
+        description
+          "A boolean indicating whether the port is external. A value of
+          True means the port is external. A value of False means the port
+          is internal.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q";
+      }
+      leaf oper-point-to-point {
+        type boolean;
+        config false;
+        description
+          "For a port running spanning tree, this object represents the
+          operational point-to-point status of the LAN segment attached to
+          this port. It indicates whether a port is considered to have a
+          point-to-point connection.
+          
+          If admin-point-to-point is set to auto(2), then the value of
+          oper-point-to-point is determined in accordance with the specific
+          procedures defined for the MAC entity concerned, as defined in
+          IEEE Std 802.1AC.
+          
+          The value is determined dynamically; that is, it is re-evaluated
+          whenever the value of admin-point-to-point changes, and whenever
+          the specific procedures defined for the MAC entity evaluate a
+          change in its point-to-point status.";
+        reference
+          "IEEE Std 802.1AC; 12.4.2 of IEEE Std 802.1Q";
+      }
+      leaf media-dependent-overhead {
+        type uint8;
+        units "octets";
+        config false;
+        description
+          "The portMediaDependentOverhead parameter provides the number of
+          additional octets for media-dependent framing. The overhead
+          includes all octets prior the first octet of the Destination
+          Address field and all octets after the last octet of the frame
+          check sequence.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q";
+      }
+      container statistics {
+        config false;
+        description
+          "Container of operational state node information associated with
+          the bridge port.";
+        uses dot1qtypes:bridge-port-statistics-grouping;
+        leaf discard-on-ingress-filtering {
+          when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+            description
+              "Applies to non TPMRs";
+          }
+          if-feature "ingress-filtering";
+          type yang:counter64;
+          description
+            "The number of frames that were discarded as a result of Ingress
+            Filtering being enabled.
+            
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other times
+            as indicated by the value of 'discontinuity-time'.";
+          reference
+            "12.6.1.1.3 of IEEE Std 802.1Q";
+        }
+      }
+      list vid-translations {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        key "local-vid";
+        description
+          "To configure the VID Translation Table (6.9) associated with a
+          Port. This object is not applicable to Ports that do not support a
+          VID Translation Table. The default configuration of the table has
+          the value of the Relay VID equal to the value of the Local VID. If
+          no local VID is configured, then it is assumed that the relay VID
+          is the same value as the local VID.
+          
+          If the port supports an Egress VID translation table, the VID
+          Translation Configuration object configures the Local VID to Relay
+          VID mapping on ingress only. If an Egress VID translation is not
+          supported, the VID Translation Configuration object defines a
+          single bidirectional mapping. In this case, the Bridge should not
+          allow multiple keys ('local-vid') mapped to the same 'relay-vid'
+          value.";
+        leaf local-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Local VID after translation received at the ISS or EISS.";
+          reference
+            "12.10.1.8, 6.9 of IEEE Std 802.1Q";
+        }
+        leaf relay-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Relay VID received before translation received at ISS or
+            EISS.";
+          reference
+            "12.10.1.8, 6.9 of IEEE Std 802.1Q";
+        }
+      }
+      list egress-vid-translations {
+        when
+          "/dot1q:bridges/dot1q:bridge[dot1q:name=current()"+
+          "/../dot1q:bridge-name]/dot1q:component[name=current()"+
+          "/../dot1q:component-name]/dot1q:type !="+
+          "'dot1q:d-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        key "relay-vid";
+        description
+          "To configure the Egress VID Translation Table (6.9) associated
+          with a Port. This object is not applicable to Ports that do not
+          support an Egress VID Translation Table. The default configuration
+          of the table has the value of the Local VID equal to the value of
+          the Relay VID. If no Relay VID is configured, then it is assumed
+          that the local VID is the same value as the relay VID.";
+        leaf relay-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Relay VID received before translation received at ISS or
+            EISS.";
+          reference
+            "12.10.1.9, 6.9 of IEEE Std 802.1Q";
+        }
+        leaf local-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Local VID after translation received at the ISS or EISS.";
+          reference
+            "12.10.1.9, 6.9 of IEEE Std 802.1Q";
+        }
+      }
+    }
+  }
+}

--- a/yang/ieee802-dot1q-types.yang
+++ b/yang/ieee802-dot1q-types.yang
@@ -1,4 +1,5 @@
 module ieee802-dot1q-types {
+  yang-version "1.1";
   namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-types;
   prefix dot1q-types;
   import ietf-yang-types {
@@ -7,40 +8,85 @@ module ieee802-dot1q-types {
   organization
     "IEEE 802.1 Working Group";
   contact
-    "WG-URL: http://www.ieee802.org/1/
-    WG-EMail: stds-802-1-L@ieee.org
+    "WG-URL: http://ieee802.org/1/
+    WG-EMail: stds-802-1-l@ieee.org
     
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
-            IEEE Standards Association
-            445 Hoes Lane
-            P.O. Box 1331
-            Piscataway
-            NJ 08855-1331
-            USA
+    IEEE Standards Association
+    445 Hoes Lane
+    Piscataway, NJ 08854
+    USA
     
-    E-mail: STDS-802-1-L@IEEE.ORG";
+    E-mail: stds-802-1-chairs@ieee.org";
   description
-    "Common types used within dot1Q-bridge modules.";
+    "Common types used within dot1Q-bridge modules.
+    
+    Copyright (C) IEEE (2023).
+    
+    This version of this YANG module is part of IEEE Std 802.1Q; see the
+    standard itself for full legal notices.";    
+  revision 2023-10-26 {
+    description
+      "Published as part of IEEE Std 802.1Qcj-2023.  This revision adds
+      the isid-type.
+      
+      The following reference statement identifies each referenced IEEE
+      Standard as updated by applicable amendments.";
+    reference
+      "IEEE Std 802.1Q Bridges and Bridged Networks: 
+      IEEE Std 802.1Q-2022, IEEE Std 802.1Qcz-2023, IEEE Std 802.1Qcw-2023,
+      IEEE Std 802.1Qcj-2023. 
+      IEEE Std 802 Overview and Architecture: IEEE Std 802-2014.";
+  }
+  revision 2023-10-22 {
+    description
+      "Published as part of IEEE Std 802.1Qcw-2023.
+      
+      The following reference statement identifies each referenced IEEE
+      Standard as updated by applicable amendments.";
+    reference
+      "IEEE Std 802.1Q Bridges and Bridged Networks: 
+      IEEE Std 802.1Q-2022, IEEE Std 802.1Qcz-2023, IEEE Std 802.1Qcw-2023. 
+      IEEE Std 802 Overview and Architecture: 
+      IEEE Std 802-2014.";
+  }
+  revision 2023-07-03 {
+    description
+      "Published as part of IEEE Std 802.1Qcz-2023.";
+    reference
+      "IEEE Std 802.1Qcz-2023, Bridges and Bridged Networks - Congestion
+      Isolation.";
+  }
+  revision 2022-10-29 {
+    description
+      "Published as part of IEEE Std 802.1Q-2022.";
+    reference
+      "IEEE Std 802.1Q-2022, Bridges and Bridged Networks.";
+  }
+  revision 2020-06-04 {
+    description
+      "Published as part of IEEE Std 802.1Qcx-2020.";
+    reference
+      "IEEE Std 802.1Qcx-2020, Bridges and Bridged Networks - YANG Data
+      Model for Connectivity Fault Management.";
+  }
   revision 2018-03-07 {
     description
-      "Published as part of IEEE Std 802.1Q-2018.
-      Initial version.";
+      "Published as part of IEEE Std 802.1Q-2018.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-  
   identity dot1q-vlan-type {
     description
-      "Base identity from which all 802.1Q VLAN tag types are derived
-      from.";
+      "Base identity from which all 802.1Q VLAN tag types are derived.";
   }
   identity c-vlan {
     base dot1q-vlan-type;
     description
-      "An 802.1Q Customer VLAN, using the 81-00 EtherType";
+      "An 802.1Q Customer VLAN, using the 81-00 EtherType.";
     reference
-      "5.5 of IEEE Std 802.1Q-2018";
+      "5.5 of IEEE Std 802.1Q";
   }
   identity s-vlan {
     base dot1q-vlan-type;
@@ -48,7 +94,51 @@ module ieee802-dot1q-types {
       "An 802.1Q Service VLAN, using the 88-A8 EtherType originally
       introduced in 802.1ad, and incorporated into 802.1Q (2011)";
     reference
-      "5.6 of IEEE Std 802.1Q-2018";
+      "5.6 of IEEE Std 802.1Q";
+  }
+  identity transmission-selection-algorithm {
+    description
+      "Specify the transmission selection algorithms of IEEE Std 802.1Q
+      Table 8-6";
+  }
+  identity strict-priority {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the strict priority transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q";
+  }
+  identity credit-based-shaper {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the credit-based shaper transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q";
+  }
+  identity enhanced-transmission-selection {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the enhanced transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q";
+  }
+  identity asynchronous-traffic-shaping {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the asynchronous transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q";
+  }
+  identity vendor-specific {
+    base transmission-selection-algorithm;
+    description
+      "Indicates a vendor specific transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q";
+  }
+  identity type-of-operation {
+    description
+      "Represents the operation type (name).";
   }
   typedef name-type {
     type string {
@@ -60,23 +150,31 @@ module ieee802-dot1q-types {
   }
   typedef port-number-type {
     type uint32 {
-      range "1..65535";
+      range "1..4095";
     }
     description
-      "The port number of the Bridge port for which this entry
-      contains Bridge management information.";
+      "The port number of the Bridge port for which this entry contains
+      Bridge management information.";
   }
   typedef priority-type {
     type uint8 {
       range "0..7";
     }
     description
-      "A range of priorities from 0 to 7 (inclusive). The Priority
-      Code Point (PCP) is a 3-bit field that refers to the class of
-      service associated with an 802.1Q VLAN tagged frame. The field
-      specifies a priority value between 0 and 7, these values can be
-      used by quality of service (QoS) to prioritize different classes
-      of traffic.";
+      "A range of priorities from 0 to 7 (inclusive). The Priority Code
+      Point (PCP) is a 3-bit field that refers to the class of service
+      associated with an 802.1Q VLAN tagged frame. The field specifies a
+      priority value between 0 and 7, these values can be used by quality of
+      service (QoS) to prioritize different classes of traffic.";
+  }
+  typedef num-traffic-class-type {
+    type uint8 {
+      range "1..8";
+    }
+    description
+      "The number of traffic classes supported or participating in a
+      particular feature. There are between 1 and 8 supported traffic
+      classes defined by IEEE Std 802.1Q.";
   }
   typedef vid-range-type {
     type string {
@@ -87,13 +185,12 @@ module ieee802-dot1q-types {
         "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
     }
     description
-      "A list of VLAN Ids, or non overlapping VLAN ranges, in
-      ascending order, between 1 and 4094.
+      "A list of VLAN IDs, or non overlapping VLAN ranges, in ascending
+      order, between 1 and 4094.
       
-      This type is used to match an ordered list of VLAN Ids, or
-      contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the
-      range 1 to 4094, and included in the list in non overlapping
-      ascending order.
+      This type is used to match an ordered list of VLAN IDs, or contiguous
+      ranges of VLAN IDs. Valid VLAN IDs must be in the range 1 to 4094, and
+      included in the list in non overlapping ascending order.
       
       For example: 1,10-100,250,500-1000";
   }
@@ -105,23 +202,21 @@ module ieee802-dot1q-types {
       "The vlanid type uniquely identifies a VLAN. This is the 12-bit
       VLAN-ID used in the VLAN Tag header. The range is defined by the
       referenced specification. This type is in the value set and its
-      semantics equivalent to the VlanId textual convention of the
-      SMIv2.";
+      semantics equivalent to the VlanId textual convention of the SMIv2.";
   }
   typedef vlan-index-type {
     type uint32 {
       range "1..4094 | 4096..4294967295";
     }
     description
-      "A value used to index per-VLAN tables. Values of 0 and 4095 are
-      not permitted. The range of valid VLAN indices. If the value is
-      greater than 4095, then it represents a VLAN with scope local to
-      the particular agent, i.e., one without a global VLAN-ID
-      assigned to it. Such VLANs are outside the scope of IEEE 802.1Q,
-      but it is convenient to be able to manage them in the same way
-      using this YANG module.";
+      "A value used to index per-VLAN tables. Values of 0 and 4095 are not
+      permitted. The range of valid VLAN indices. If the value is greater
+      than 4095, then it represents a VLAN with scope local to the
+      particular agent, i.e., one without a global VLAN-ID assigned to it.
+      Such VLANs are outside the scope of IEEE 802.1Q, but it is convenient
+      to be able to manage them in the same way using this YANG module.";
     reference
-      "9.6 of IEEE Std 802.1Q-2018";
+      "9.6 of IEEE Std 802.1Q";
   }
   typedef mstid-type {
     type uint32 {
@@ -131,7 +226,7 @@ module ieee802-dot1q-types {
       "In an MSTP Bridge, an MSTID, i.e., a value used to identify a
       spanning tree (or MST) instance";
     reference
-      "13.8 of IEEE Std 802.1Q-2018";
+      "13.8 of IEEE Std 802.1Q";
   }
   typedef pcp-selection-type {
     type enumeration {
@@ -155,8 +250,7 @@ module ieee802-dot1q-types {
     description
       "Priority Code Point selection types.";
     reference
-      "12.6.2.5.3 of IEEE Std 802.1Q-2018
-      6.9.3 of IEEE Std 802.1Q-2018";
+      "12.6.2.5.3, 6.9.3 of IEEE Std 802.1Q";
   }
   typedef protocol-frame-format-type {
     type enumeration {
@@ -184,18 +278,17 @@ module ieee802-dot1q-types {
     description
       "A value representing the frame format to be matched.";
     reference
-      "12.10.1.7.1 of IEEE Std 802.1Q-2018";
+      "12.10.1.7.1 of IEEE Std 802.1Q";
   }
   typedef ethertype-type {
     type string {
       pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
     }
     description
-      "The EtherType value represented in the canonical order defined
-      by IEEE 802. The canonical representation uses uppercase
-      characters.";
+      "The EtherType value represented in the canonical order defined by
+      IEEE 802. The canonical representation uses uppercase characters.";
     reference
-      "9.2 of IEEE Std 802-2014";
+      "9.2 of IEEE Std 802";
   }
   typedef dot1q-tag-type {
     type identityref {
@@ -204,23 +297,36 @@ module ieee802-dot1q-types {
     description
       "Identifies a specific 802.1Q tag type";
     reference
-      "IEEE Std 802.1Q-2018";
+      "9.5 IEEE Std 802.1Q";
   }
   typedef traffic-class-type {
     type uint8 {
       range "0..7";
     }
     description
-      "This is the numerical value associated with a traffic class in
-      a Bridge. Larger values are associated with higher priority
-      traffic classes.";
+      "This is the numerical value associated with a traffic class in a
+      Bridge. Larger values are associated with higher priority traffic
+      classes.";
     reference
-      "3.239 of IEEE Std 802.1Q-2018";
+      "3.273 of IEEE Std 802.1Q";
+  }
+    typedef isid-type {
+    type uint32 {
+      range "1|255..16777214";
+    }
+    description
+      "The i-sid type represents a Backbone Service Instance Identifier
+      (I-SID). This is the 24-bit I-SID field used in the I-TAG TCI of a
+      Provider Backbone Bridging frame. The values 0, 2-254, and 16777215
+      are reserved for future standardization. The value 255 is dedicated
+      to use by the SPB protocol.";
+    reference
+      "3.108, 9.7 of IEEE Std 802.1Q-2022";
   }
   grouping dot1q-tag-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN, matching both the
-      EtherType and a single VLAN Id.";
+      EtherType and a single VLAN ID.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -231,13 +337,13 @@ module ieee802-dot1q-types {
       type vlanid;
       mandatory true;
       description
-        "VLAN Id";
+        "VLAN ID";
     }
   }
   grouping dot1q-tag-or-any-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN, matching both the
-      EtherType and a single VLAN Id or 'any' to match on any VLAN Id.";
+      EtherType and a single VLAN ID or 'any' to match on any VLAN ID.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -251,20 +357,20 @@ module ieee802-dot1q-types {
           enum any {
             value 4095;
             description
-              "Matches 'any' VLAN in the range 1 to 4094 that is not
-              matched by a more specific VLAN Id match";
+              "Matches 'any' VLAN in the range 1 to 4094 that is not matched
+              by a more specific VLAN ID match";
           }
         }
       }
       mandatory true;
       description
-        "VLAN Id or any";
+        "VLAN ID or any";
     }
   }
   grouping dot1q-tag-ranges-classifier-grouping {
     description
-      "A grouping which represents an 802.1Q VLAN that matches a range
-      of VLAN Ids.";
+      "A grouping which represents an 802.1Q VLAN that matches a range of
+      VLAN IDs.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -275,14 +381,14 @@ module ieee802-dot1q-types {
       type vid-range-type;
       mandatory true;
       description
-        "VLAN Ids";
+        "VLAN IDs";
     }
   }
   grouping dot1q-tag-ranges-or-any-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN, matching both the
-      EtherType and a single VLAN Id, ordered list of ranges, or 'any'
-      to match on any VLAN Id.";
+      EtherType and a single VLAN ID, ordered list of ranges, or 'any' to
+      match on any VLAN ID.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -302,24 +408,22 @@ module ieee802-dot1q-types {
       }
       mandatory true;
       description
-        "VLAN Ids or any";
+        "VLAN IDs or any";
     }
   }
   grouping priority-regeneration-table-grouping {
     description
-      "The priority regeneration table provides the ability to map
-      incoming priority values on a per-Port basis, under management
-      control.";
+      "The priority regeneration table provides the ability to map incoming
+      priority values on a per-Port basis, under management control.";
     reference
-      "6.9.4 of IEEE Std 802.1Q-2018";
+      "6.9.4 of IEEE Std 802.1Q";
     leaf priority0 {
       type priority-type;
       default "0";
       description
         "Priority 0";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority1 {
       type priority-type;
@@ -327,8 +431,7 @@ module ieee802-dot1q-types {
       description
         "Priority 1";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority2 {
       type priority-type;
@@ -336,8 +439,7 @@ module ieee802-dot1q-types {
       description
         "Priority 2";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority3 {
       type priority-type;
@@ -345,8 +447,7 @@ module ieee802-dot1q-types {
       description
         "Priority 3";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority4 {
       type priority-type;
@@ -354,8 +455,7 @@ module ieee802-dot1q-types {
       description
         "Priority 4";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority5 {
       type priority-type;
@@ -363,8 +463,7 @@ module ieee802-dot1q-types {
       description
         "Priority 5";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority6 {
       type priority-type;
@@ -372,8 +471,7 @@ module ieee802-dot1q-types {
       description
         "Priority 6";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
     leaf priority7 {
       type priority-type;
@@ -381,58 +479,53 @@ module ieee802-dot1q-types {
       description
         "Priority 7";
       reference
-        "12.6.2.3 of IEEE Std 802.1Q-2018
-        6.9.4 of IEEE Std 802.1Q-2018";
+        "12.6.2.3, 6.9.4 of IEEE Std 802.1Q";
     }
   }
   grouping pcp-decoding-table-grouping {
     description
-      "The Priority Code Point decoding table enables the decoding of
-      the priority and drop-eligible parameters from the PCP.";
+      "The Priority Code Point decoding table enables the decoding of the
+      priority and drop-eligible parameters from the PCP.";
     reference
-      "6.9.3 of IEEE Std 802.1Q-2018";
+      "6.9.3 of IEEE Std 802.1Q";
     list pcp-decoding-map {
       key "pcp";
       description
-        "This map associates the priority code point field found in
-        the VLAN to a priority and drop eligible value based upon the
-        priority code point selection type.";
+        "This map associates the priority code point field found in the VLAN
+        with a priority and drop eligible value based upon the priority code
+        point selection type.";
       leaf pcp {
         type pcp-selection-type;
         description
           "The priority code point selection type.";
         reference
-          "12.6.2.7 of IEEE Std 802.1Q-2018
-          6.9.3 of IEEE Std 802.1Q-2018";
+          "12.6.2.7, 6.9.3 of IEEE Std 802.1Q";
       }
       list priority-map {
         key "priority-code-point";
         description
-          "This map associated a priority code point value to priority
+          "This map associates a priority code point value with priority
           and drop eligible parameters.";
         leaf priority-code-point {
           type priority-type;
           description
             "Priority associated with the pcp.";
           reference
-            "12.6.2.7 of IEEE Std 802.1Q-2018
-            6.9.3 of IEEE Std 802.1Q-2018";
+            "12.6.2.7, 6.9.3 of IEEE Std 802.1Q";
         }
         leaf priority {
           type priority-type;
           description
             "Priority associated with the pcp.";
           reference
-            "12.6.2.7 of IEEE Std 802.1Q-2018
-            6.9.3 of IEEE Std 802.1Q-2018";
+            "12.6.2.7, 6.9.3 of IEEE Std 802.1Q";
         }
         leaf drop-eligible {
           type boolean;
           description
             "Drop eligible value for pcp";
           reference
-            "12.6.2.7 of IEEE Std 802.1Q-2018
-            6.9.3 of IEEE Std 802.1Q-2018";
+            "12.6.2.7, 6.9.3 of IEEE Std 802.1Q";
         }
       }
     }
@@ -442,69 +535,62 @@ module ieee802-dot1q-types {
       "The Priority Code Point encoding table encodes the priority and
       drop-eligible parameters in the PCP field of the VLAN tag.";
     reference
-      "12.6.2.9 of IEEE Std 802.1Q-2018
-      6.9.3 of IEEE Std 802.1Q-2018";
+      "12.6.2.9, 6.9.3 of IEEE Std 802.1Q";
     list pcp-encoding-map {
       key "pcp";
       description
-        "This map associated the priority and drop-eligible parameters
-        to the priority used to encode the PCP of the VLAN based upon
+        "This map associates the priority and drop-eligible parameters
+        with the priority used to encode the PCP of the VLAN based upon
         the priority code point selection type.";
       leaf pcp {
         type pcp-selection-type;
         description
           "The priority code point selection type.";
         reference
-          "12.6.2.7 of IEEE Std 802.1Q-2018
-          6.9.3 of IEEE Std 802.1Q-2018";
+          "12.6.2.7, 6.9.3 of IEEE Std 802.1Q";
       }
       list priority-map {
         key "priority dei";
         description
-          "This map associated the priority and drop-eligible
-          parameters to the priority code point field of the VLAN tag.";
+          "This map associates the priority and drop-eligible parameters
+          with the priority code point field of the VLAN tag.";
         leaf priority {
           type priority-type;
           description
             "Priority associated with the pcp.";
           reference
-            "12.6.2.7 of IEEE Std 802.1Q-2018
-            6.9.3 of IEEE Std 802.1Q-2018";
+            "12.6.2.7, 6.9.3 of IEEE Std 802.1Q";
         }
         leaf dei {
           type boolean;
           description
             "The drop eligible value.";
           reference
-            "12.6.2 of IEEE Std 802.1Q-2018
-            8.6.6 of IEEE Std 802.1Q-2018";
+            "12.6.2, 8.6.6 of IEEE Std 802.1Q";
         }
         leaf priority-code-point {
           type priority-type;
           description
             "PCP value for priority when DEI value";
           reference
-            "12.6.2.9 of IEEE Std 802.1Q-2018
-            6.9.3 of IEEE Std 802.1Q-2018";
+            "12.6.2.9, 6.9.3 of IEEE Std 802.1Q";
         }
       }
     }
   }
   grouping service-access-priority-table-grouping {
     description
-      "The Service Access Priority Table associates a received
-      priority with a serice access priority.";
+      "The Service Access Priority Table associates a received priority with
+      a service access priority.";
     reference
-      "12.6.2.17 of IEEE Std 802.1Q-2018
-      6.13.1 of IEEE Std 802.1Q-2018";
+      "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     leaf priority0 {
       type priority-type;
       default "0";
       description
         "Service access priority value for priority 0";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority1 {
       type priority-type;
@@ -512,8 +598,7 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 1";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority2 {
       type priority-type;
@@ -521,8 +606,7 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 2";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority3 {
       type priority-type;
@@ -530,8 +614,7 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 3";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority4 {
       type priority-type;
@@ -539,8 +622,7 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 4";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority5 {
       type priority-type;
@@ -548,8 +630,7 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 5";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority6 {
       type priority-type;
@@ -557,8 +638,7 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 6";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
     leaf priority7 {
       type priority-type;
@@ -566,36 +646,40 @@ module ieee802-dot1q-types {
       description
         "Service access priority value for priority 7";
       reference
-        "12.6.2.17 of IEEE Std 802.1Q-2018
-        6.13.1 of IEEE Std 802.1Q-2018";
+        "12.6.2.17, 6.13.1 of IEEE Std 802.1Q";
     }
   }
   grouping traffic-class-table-grouping {
     description
       "The Traffic Class Table models the operations that can be
-      performed on, or inquire about, the current contents of the
+      performed on, or can inquire about, the current contents of the
       Traffic Class Table (8.6.6) for a given Port.";
     reference
-      "12.6.3 of IEEE Std 802.1Q-2018
-      8.6.6 of IEEE Std 802.1Q-2018";
+      "12.6.3, 8.6.6 of IEEE Std 802.1Q";
     list traffic-class-map {
       key "priority";
+      status "deprecated";
       description
-        "The priority index into the traffic class table.";
+        "The priority index into the traffic class table. This list modeled
+        the Traffic Class Table incorrectly. available-traffic-class should
+        be a single value per port and not a list of all possible
+        available-traffic-class. For more information see maintenance issue
+        0230. The status of this object is deprecated. It is replaced by
+        sibling container traffic-class-table.";
       leaf priority {
         type priority-type;
         description
           "The priority of the traffic class entry.";
         reference
-          "8.6.6 of IEEE Std 802.1Q-2018";
+          "8.6.6 of IEEE Std 802.1Q";
       }
       list available-traffic-class {
         key "num-traffic-class";
         description
-          "The traffic class index associated with a given priority
-          within the traffic class table.";
+          "The traffic class index associated with a given priority within
+          the traffic class table.";
         reference
-          "8.6.6 of IEEE Std 802.1Q-2018";
+          "8.6.6 of IEEE Std 802.1Q";
         leaf num-traffic-class {
           type uint8 {
             range "1..8";
@@ -603,16 +687,133 @@ module ieee802-dot1q-types {
           description
             "The available number of traffic classes.";
           reference
-            "8.6.6 of IEEE Std 802.1Q-2018";
+            "8.6.6 of IEEE Std 802.1Q";
         }
         leaf traffic-class {
           type traffic-class-type;
           description
-            "The traffic class index associated with a given traffic
-            class entry.";
+            "The traffic class index associated with a given traffic class
+            entry.";
           reference
-            "8.6.6 of IEEE Std 802.1Q-2018";
+            "8.6.6 of IEEE Std 802.1Q";
         }
+      }
+    }
+    container traffic-class-table {
+      description
+        "The priority to traffic class mapping.";
+      reference
+        "8.6.6 of IEEE Std 802.1Q";
+      leaf number-of-traffic-classes {
+        type uint8 {
+          range "1..8";
+        }
+        description
+          "The number of egress traffic classes supported on this port. This
+          object may be optionally read-only.";
+        reference
+          "12.6.3.1 of IEEE Std 802.1Q";
+      }
+      leaf priority0 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 0";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority1 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 1";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority2 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 2";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority3 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 3";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority4 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 4";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority5 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 5";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority6 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 6";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf priority7 {
+        type traffic-class-type;
+        must
+          "current() < ../number-of-traffic-classes";
+        description
+          "The traffic class index associated with priority 7";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+    }
+  }
+  grouping transmission-selection-table-grouping {
+    description
+      "The Transmission Selection Algorithm Table models the operations that
+      can be performed on, or can inquire about, the current contents of the
+      Transmission Selection Algorithm Table (12.20.2) for a given Port.";
+    reference
+      "12.20.2, 8.6.8 of IEEE Std 802.1Q";
+    list transmission-selection-algorithm-map {
+      key "traffic-class";
+      description
+        "The traffic class to index into the transmission selection table.";
+      leaf traffic-class {
+        type traffic-class-type;
+        description
+          "The traffic class of the entry.";
+        reference
+          "8.6.6 of IEEE Std 802.1Q";
+      }
+      leaf transmission-selection-algorithm {
+        type identityref {
+          base dot1q-types:transmission-selection-algorithm;
+        }
+        description
+          "Transmission selection algorithm";
+        reference
+          "8.6.8, Table 8-6 of IEEE Std 802.1Q";
       }
     }
   }
@@ -621,8 +822,7 @@ module ieee802-dot1q-types {
       "A set of control indicators, one for each Port. A Port Map,
       containing a control element for each outbound Port";
     reference
-      "8.8.1 of IEEE Std 802.1Q-2018
-      8.8.2 of IEEE Std 802.1Q-2018";
+      "8.8.1, 8.8.2 of IEEE Std 802.1Q";
     list port-map {
       key "port-ref";
       description
@@ -632,7 +832,7 @@ module ieee802-dot1q-types {
         description
           "The interface port reference associated with this map.";
         reference
-          "8.8.1 of IEEE Std 802.1Q-2018";
+          "8.8.1 of IEEE Std 802.1Q";
       }
       choice map-type {
         description
@@ -654,31 +854,29 @@ module ieee802-dot1q-types {
               }
               enum forward-filter {
                 description
-                  "Forwarded or filtered on the basis of dynamic
-                  filtering information, or on the basis of the
-                  default Group filtering behavior for the outbound
-                  Port (8.8.6) if no dynamic filtering information is
-                  present specifically for the MAC address.";
+                  "Forwarded or filtered on the basis of dynamic filtering
+                  information, or on the basis of the default Group
+                  filtering behavior for the outbound Port (8.8.6) if no
+                  dynamic filtering information is present specifically for
+                  the MAC address.";
               }
             }
             description
-              "containing a control element for each outbound Port,
-              specifying that a frame with a destination MAC address,
-              and in the case of VLAN Bridge components, VID that
-              meets this specification.";
+              "A control element for each outbound Port, specifying that
+              a frame with a destination MAC address, and in the case of
+              VLAN Bridge components, VID that meets this specification.";
             reference
-              "8.8.1 of IEEE Std 802.1Q-2018";
+              "8.8.1 of IEEE Std 802.1Q";
           }
           leaf connection-identifier {
             type port-number-type;
             description
-              "A Port MAP may contain a connection identifier (8.8.12)
-              for each outbound port. The connection identifier may be
-              associated with the Bridge Port value maintained in a
-              Dynamic Filtering Entry of the FDB for Bridge Ports.";
+              "A Port MAP may contain a connection identifier (8.8.12) for
+              each outbound port. The connection identifier may be
+              associated with the Bridge Port value maintained in a Dynamic
+              Filtering Entry of the FDB for Bridge Ports.";
             reference
-              "8.8.1 of IEEE Std 802.1Q-2018
-              8.8.12 of IEEE Std 802.1Q-2018";
+              "8.8.1, 8.8.12 of IEEE Std 802.1Q";
           }
         }
         container static-vlan-registration-entries {
@@ -704,10 +902,10 @@ module ieee802-dot1q-types {
               }
             }
             description
-              "The Registrar Administrative Control values for MVRP
-              and MIRP for the VID.";
+              "The Registrar Administrative Control values for MVRP and MIRP
+              for the VID.";
             reference
-              "8.8.2 of IEEE Std 802.1Q-2018";
+              "8.8.2 of IEEE Std 802.1Q";
           }
           leaf vlan-transmitted {
             type enumeration {
@@ -724,7 +922,7 @@ module ieee802-dot1q-types {
               "Whether frames are to be VLAN-tagged or untagged when
               transmitted.";
             reference
-              "8.8.2 of IEEE Std 802.1Q-2018";
+              "8.8.2 of IEEE Std 802.1Q";
           }
         }
         container mac-address-registration-entries {
@@ -744,12 +942,11 @@ module ieee802-dot1q-types {
               }
             }
             description
-              "containing a control element for each outbound Port,
-              specifying that a frame with a destination MAC address,
-              and in the case of VLAN Bridge components, VID that
-              meets this specification.";
+              "A control element for each outbound Port, specifying that
+              a frame with a destination MAC address, and in the case of
+              VLAN Bridge components, VID that meets this specification.";
             reference
-              "8.8.4 of IEEE Std 802.1Q-2018";
+              "8.8.4 of IEEE Std 802.1Q";
           }
         }
         container dynamic-vlan-registration-entries {
@@ -764,12 +961,11 @@ module ieee802-dot1q-types {
               }
             }
             description
-              "containing a control element for each outbound Port,
-              specifying that a frame with a destination MAC address,
-              and in the case of VLAN Bridge components, VID that
-              meets this specification.";
+              "A control element for each outbound Port, specifying that
+              a frame with a destination MAC address, and in the case of
+              VLAN Bridge components, VID that meets this specification.";
             reference
-              "8.8.5 of IEEE Std 802.1Q-2018";
+              "8.8.5 of IEEE Std 802.1Q";
           }
         }
         container dynamic-reservation-entries {
@@ -789,12 +985,11 @@ module ieee802-dot1q-types {
               }
             }
             description
-              "Containing a control element for each outbound Port,
-              specifying that a frame with a destination MAC address,
-              and in the case of VLAN Bridge components, VID that
-              meets this specification.";
+              "A control element for each outbound Port, specifying that
+              a frame with a destination MAC address, and in the case of
+              VLAN Bridge components, VID that meets this specification.";
             reference
-              "8.8.7 of IEEE Std 802.1Q-2018";
+              "8.8.7 of IEEE Std 802.1Q";
           }
         }
         container dynamic-filtering-entries {
@@ -809,12 +1004,11 @@ module ieee802-dot1q-types {
               }
             }
             description
-              "Containing a control element for each outbound Port,
-              specifying that a frame with a destination MAC address,
-              and in the case of VLAN Bridge components, VID that
-              meets this specification.";
+              "A control element for each outbound Port, specifying that
+              a frame with a destination MAC address, and in the case of
+              VLAN Bridge components, VID that meets this specification.";
             reference
-              "8.8.3 of IEEE Std 802.1Q-2018";
+              "8.8.3 of IEEE Std 802.1Q";
           }
         }
       }
@@ -824,7 +1018,7 @@ module ieee802-dot1q-types {
     description
       "Grouping of bridge port statistics.";
     reference
-      "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+      "12.6.1.1.3 of IEEE Std 802.1Q";
     leaf delay-exceeded-discards {
       type yang:counter64;
       description
@@ -832,69 +1026,66 @@ module ieee802-dot1q-types {
         transit delay through the Bridge. It is incremented by both
         transparent and source route Bridges.";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018
-        8.6.6 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3, 8.6.6 of IEEE Std 802.1Q";
     }
     leaf mtu-exceeded-discards {
       type yang:counter64;
       description
-        "The number of frames discarded by this port due to an
-        excessive size. It is incremented by both transparent and
-        source route Bridges.";
+        "The number of frames discarded by this port due to an excessive
+        size. It is incremented by both transparent and source route
+        Bridges.";
       reference
-        "12.6.1.1.3, item g) of IEEE Std 802.1Q-2018";
+        "Item g) in 12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf frame-rx {
       type yang:counter64;
       description
-        "The number of frames that have been received by this port
-        from its segment. Note that a frame received on the interface
-        corresponding to this port is only counted by this object if
-        and only if it is for a protocol being processed by the local
-        bridging function, including Bridge management frames.";
+        "The number of frames that have been received by this port from its
+        segment. Note that a frame received on the interface corresponding
+        to this port is only counted by this object if and only if it is for
+        a protocol being processed by the local bridging function, including
+        Bridge management frames.";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf octets-rx {
       type yang:counter64;
       description
-        "The total number of octets in all valid frames received
-        (including BPDUs, frames addressed to the Bridge as an end
-        station, and frames that were submitted to the Forwarding
-        Process).";
+        "The total number of octets in all valid frames received (including
+        BPDUs, frames addressed to the Bridge as an end station, and frames
+        that were submitted to the Forwarding Process).";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf frame-tx {
       type yang:counter64;
       description
-        "The number of frames that have been transmitted by this port
-        to its segment. Note that a frame transmitted on the interface
-        corresponding to this port is only counted by this object if
-        and only if it is for a protocol being processed by the local
-        bridging function, including Bridge management frames.";
+        "The number of frames that have been transmitted by this port to its
+        segment. Note that a frame transmitted on the interface
+        corresponding to this port is only counted by this object if and
+        only if it is for a protocol being processed by the local bridging
+        function, including Bridge management frames.";
     }
     leaf octets-tx {
       type yang:counter64;
       description
-        "The total number of octets that have been transmitted by this
-        port to its segment.";
+        "The total number of octets that have been transmitted by this port
+        to its segment.";
     }
     leaf discard-inbound {
       type yang:counter64;
       description
-        "Count of received valid frames that were discarded (i.e.,
-        filtered) by the Forwarding Process.";
+        "Count of received valid frames that were discarded (i.e., filtered)
+        by the Forwarding Process.";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf forward-outbound {
       type yang:counter64;
       description
-        "The number of frames forwarded to the associated MAC Entity
-        (8.5).";
+        "The number of frames forwarded to the associated MAC Entity (8.5).";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf discard-lack-of-buffers {
       type yang:counter64;
@@ -902,7 +1093,7 @@ module ieee802-dot1q-types {
         "The count of frames that were to be transmitted through the
         associated Port but were discarded due to lack of buffers.";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf discard-transit-delay-exceeded {
       type yang:counter64;
@@ -911,16 +1102,48 @@ module ieee802-dot1q-types {
         transit delay through the Bridge. It is incremented by both
         transparent and source route Bridges.";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
     }
     leaf discard-on-error {
       type yang:counter64;
       description
-        "The number of frames that were to be forwarded on the
-        associated MAC but could not be transmitted (e.g., frame would
-        be too large, 6.5.8).";
+        "The number of frames that were to be forwarded on the associated
+        MAC but could not be transmitted (e.g., frame would be too large,
+        6.5.8).";
       reference
-        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        "12.6.1.1.3 of IEEE Std 802.1Q";
+    }
+  }
+  grouping base-gate-control-entries {
+    description
+      "Grouping of gate control entries.";
+    list gate-control-entry {
+      key "index";
+      description
+        "List of gate control entries.";
+      leaf index {
+        type uint32;
+        description
+          "The index for this entry.";
+      }
+      leaf operation-name {
+        type identityref {
+          base type-of-operation;
+        }
+        mandatory true;
+        description
+          "The name (type) of the operation for this entry.";
+      }
+      leaf time-interval-value {
+        type uint32;
+        description
+          "timeIntervalValue is a 32-bit unsigned integer, representing a
+          number of nanoseconds. After timeIntervalValue nanoseconds have
+          elapsed since the completion of the previous entry in the gate
+          control list, control passes to the next entry.";
+        reference
+          "12.29.1.2.3, 8.6.8.4 of IEEE Std 802.1Q";
+      }
     }
   }
 }

--- a/yang/ieee802-types.yang
+++ b/yang/ieee802-types.yang
@@ -1,0 +1,336 @@
+module ieee802-types {
+  yang-version "1.1";
+  namespace urn:ieee:std:802.1Q:yang:ieee802-types;
+  prefix ieee;
+  organization
+    "IEEE 802.1 Working Group";
+  contact
+    "WG-URL: http://ieee802.org/1/
+    WG-EMail: stds-802-1-l@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+          IEEE Standards Association
+          445 Hoes Lane
+          Piscataway, NJ 08854
+          USA
+
+    E-mail: stds-802-1-chairs@ieee.org";
+  description
+    "This module contains a collection of generally useful derived data
+    types for IEEE YANG models.
+
+    Copyright (C) IEEE (2023). All rights reserved.
+
+    This version of this YANG module is part of IEEE Std 802.1Q; see the
+    standard itself for full legal notices.";
+  revision 2023-10-22 {
+    description
+      "Published as part of IEEE Std 802.1Qcw-2023.
+
+      The following reference statement identifies each referenced IEEE
+      Standard as updated by applicable amendments.";
+    reference
+      "IEEE Std 802.1Q Bridges and Bridged Networks:
+      IEEE Std 802.1Q-2022, IEEE Std 802.1Qcz-2023, IEEE Std 802.1Qcw-2023. 
+      IEEE Std 802 Overview and Architecture:
+      IEEE Std 802-2014.
+      IEEE 802.1AS Timing and Synchronization for Time-Sensitive Applications:
+      IEEE Std 802.1AS-2020.";
+  }
+  revision 2022-10-29 {
+    description
+      "Published as part of IEEE Std 802.1Q-2022.";
+    reference
+      "IEEE Std 802.1Q-2022, Bridges and Bridged Networks.";
+  }
+  revision 2022-03-16 {
+    description
+      "Published as part of IEEE Std 802.1ABcu.";
+    reference
+      "IEEE Std 802.1AB-2016";
+  }
+  revision 2020-06-04 {
+    description
+      "Published as part of IEEE Std 802.1Qcx-2020. Second version.";
+    reference
+      "IEEE Std 802.1Qcx-2020, Bridges and Bridged Networks - YANG Data
+      Model for Connectivity Fault Management.";
+  }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018. Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  typedef mac-address {
+    type string {
+      pattern "[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){5}";
+    }
+    description
+      "The mac-address type represents a MAC address in the canonical format
+      and hexadecimal format specified by IEEE Std 802. The hexadecimal
+      representation uses uppercase characters.";
+    reference
+      "3.1, 8.1 of IEEE Std 802";
+  }
+  typedef chassis-id-subtype-type {
+    type enumeration {
+      enum chassis-component {
+        value 1;
+        description
+          "Represents a chassis identifier based on the value of the
+          entPhysicalAlias object (defined in IETF RFC 2737) for a chassis
+          component (i.e., an entPhysicalClass value of chassis(3)).";
+      }
+      enum interface-alias {
+        value 2;
+        description
+          "Represents a chassis identifier based on the value of the ifAlias
+          object (defined in IETF RFC 2863) for an interface on the
+          containing chassis.";
+      }
+      enum port-component {
+        value 3;
+        description
+          "Represents a chassis identifier based on the value of the
+          entPhysicalAlias object (defined in IETF RFC 2737) for a port or
+          backplane component (i.e., entPhysicalClass value of port(10) or
+          backplane(4)), within the containing chassis.";
+      }
+      enum mac-address {
+        value 4;
+        description
+          "Represents a chassis identifier based on the value of a unicast
+          source address (encoded in network byte order and IEEE 802.3
+          bit significance), of a port on the containing chassis as
+          defined in IEEE Std 802.";
+      }
+      enum network-address {
+        value 5;
+        description
+          "Represents a chassis identifier based on a network address,
+          associated with a particular chassis. The encoded address is
+          actually composed of two fields. The first field is a single
+          octet, representing the IANA AddressFamilyNumbers value for the
+          specific address type, and the second field is the network address
+          value.";
+      }
+      enum interface-name {
+        value 6;
+        description
+          "Represents a chassis identifier based on the value of the ifName
+          object (defined in IETF RFC 2863) for an interface on the
+          containing chassis.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a chassis identifier based on a locally defined value.";
+      }
+    }
+    description
+      "The source of a chassis identifier.";
+    reference
+      "IEEE Std 802
+      IETF RFC 2737
+      IETF RFC 2863";
+  }
+  typedef chassis-id-type {
+    type string {
+      length "1..255";
+    }
+    description
+      "The format of a chassis identifier string. Objects of this type are
+      always used with an associated chassis-id-subtype object, which
+      identifies the format of the particular chassis-id object
+      instance.
+
+      If the associated chassis-id-subtype object has a value of
+      chassis-component, then the octet string identifies a particular
+      instance of the entPhysicalAlias object (defined in IETF RFC 2737) for
+      a chassis component (i.e., an entPhysicalClass value of chassis(3)).
+
+      If the associated chassis-id-subtype object has a value of
+      interface-alias, then the octet string identifies a particular
+      instance of the ifAlias object (defined in IETF RFC 2863) for an
+      interface on the containing chassis. If the particular ifAlias object
+      does not contain any values, another chassis identifier type should be
+      used.
+
+      If the associated chassis-id-subtype object has a value of
+      port-component, then the octet string identifies a particular instance
+      of the entPhysicalAlias object (defined in IETF RFC 2737) for a port
+      or backplane component within the containing chassis.
+
+      If the associated chassis-id-subtype object has a value of
+      mac-address, then this string identifies a particular unicast source
+      address (encoded in network byte order and IEEE 802.3 bit
+      significance), of a port on the containing chassis as defined in
+      IEEE Std 802.
+
+      If the associated chassis-id-subtype object has a value of
+      network-address, then this string identifies a particular network
+      address, encoded in network byte order, associated with one or more
+      ports on the containing chassis. The first octet contains the IANA
+      Address Family Numbers enumeration value for the specific address
+      type, and octets 2 through N contain the network address value in
+      network byte order.
+
+      If the associated chassis-id-subtype object has a value of
+      interface-name, then the octet string identifies a particular instance
+      of the ifName object (defined in IETF RFC 2863) for an interface on
+      the containing chassis. If the particular ifName object does not
+      contain any values, another chassis identifier type should be used.
+
+      If the associated chassis-id-subtype object has a value of local,
+      then this string identifies a locally assigned Chassis ID.";
+    reference
+      "IEEE Std 802
+      IETF RFC 2737
+      IETF RFC 2863";
+  }
+  typedef port-id-subtype-type {
+    type enumeration {
+      enum interface-alias {
+        value 1;
+        description
+          "Represents a port identifier based on the ifAlias MIB object,
+          defined in IETF RFC 2863.";
+      }
+      enum port-component {
+        value 2;
+        description
+          "Represents a port identifier based on the value of
+          entPhysicalAlias (defined in IETF RFC 2737) for a port component
+          (i.e., entPhysicalClass value of port(10)), within the containing
+          chassis.";
+      }
+      enum mac-address {
+        value 3;
+        description
+          "Represents a port identifier based on a unicast source address
+          (encoded in network byte order and IEEE 802.3 bit significance),
+          which has been detected by the agent and associated with a
+          particular port (IEEE Std 802).";
+      }
+      enum network-address {
+        value 4;
+        description
+          "Represents a port identifier based on a network address, detected
+          by the agent and associated with a particular port.";
+      }
+      enum interface-name {
+        value 5;
+        description
+          "Represents a port identifier based on the ifName MIB object,
+          defined in IETF RFC 2863.";
+      }
+      enum agent-circuit-id {
+        value 6;
+        description
+          "Represents a port identifier based on the agent-local identifier
+          of the circuit (defined in RFC 3046), detected by the agent and
+          associated with a particular port.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a port identifier based on a value locally assigned.";
+      }
+    }
+    description
+      "The source of a particular type of port identifier.";
+    reference
+      "IEEE Std 802
+      IETF RFC 2737
+      IETF RFC 2863
+      IETF RFC 3046";
+  }
+  typedef port-id-type {
+    type string {
+      length "1..255";
+    }
+    description
+      "The format of a port identifier string. Objects of this type are
+      always used with an associated port-id-subtype object, which
+      identifies the format of the particular port-id object instance.
+
+      If the associated port-id-subtype object has a value of
+      interface-alias, then the octet string identifies a particular
+      instance of the ifAlias object (defined in IETF RFC 2863). If the
+      particular ifAlias object does not contain any values, another port
+      identifier type should be used.
+
+      If the associated port-id-subtype object has a value of
+      port-component, then the octet string identifies a particular instance
+      of the entPhysicalAlias object (defined in IETF RFC 2737) for a port
+      or backplane component.
+
+      If the associated port-id-subtype object has a value of
+      mac-address, then this string identifies a particular unicast source
+      address (encoded in network byte order and IEEE 802.3 bit
+      significance) associated with the port (IEEE Std 802).
+
+      If the associated port-id-subtype object has a value of
+      network-address, then this string identifies a network address
+      associated with the port. The first octet contains the IANA
+      AddressFamilyNumbers enumeration value for the specific address type,
+      and octets 2 through N contain the networkAddress address value in
+      network byte order.
+
+      If the associated port-id-subtype object has a value of
+      interface-name, then the octet string identifies a particular instance
+      of the ifName object (defined in IETF RFC 2863). If the particular
+      ifName object does not contain any values, another port identifier
+      type should be used.
+
+      If the associated port-id-subtype object has a value of
+      agent-circuit-id, then this string identifies a agent-local identifier
+      of the circuit (defined in RFC 3046).
+
+      If the associated port-id-subtype object has a value of local,
+      then this string identifies a locally assigned port ID.";
+    reference
+      "IEEE Std 802
+      IETF RFC 2737
+      IETF RFC 2863
+      IETF RFC 3046";
+  }
+  grouping rational-grouping {
+    description
+      "Definition of a non-negative rational number.";
+    leaf numerator {
+      type uint32;
+      description
+        "Numerator of the rational number.";
+    }
+    leaf denominator {
+      type uint32 {
+        range "1..4294967295";
+      }
+      description
+        "Denominator of the rational number.";
+    }
+  }
+  grouping ptp-time-grouping {
+    description
+      "This grouping specifies a PTP timestamp, represented as a 48-bit
+      unsigned integer number of seconds and a 32-bit unsigned integer
+      number of nanoseconds.";
+    reference
+      "6.4.3.4 of IEEE Std 802.1AS";
+    leaf seconds {
+      type uint64;
+      description
+        "This is the integer portion of the timestamp in units of seconds.
+        The upper 16 bits are always zero.";
+    }
+    leaf nanoseconds {
+      type uint32;
+      description
+        "This is the fractional portion of the timestamp in units of
+        nanoseconds. This value is always less than 10^9.";
+    }
+  }
+}


### PR DESCRIPTION
As we test the changes introduced on devel branch to support bridges we found the following issue:
1- memory utilis path has been changed, hence the interfaces plugin couldn't compile as its referencing the old memory.h path.
2- bridge yang modules are outdate and missing some dependencies.

This is a PR against devel branch, as a start to help continue working on devel branch for full support bridges.